### PR TITLE
use faster and more idiomatic frequency counting in tutorial

### DIFF
--- a/docs/src/tut1.rst
+++ b/docs/src/tut1.rst
@@ -42,12 +42,17 @@ as well as words that only appear once in the corpus:
 >>>          for document in documents]
 >>>
 >>> # remove words that appear only once
->>> all_tokens = sum(texts, [])
->>> tokens_once = set(word for word in set(all_tokens) if all_tokens.count(word) == 1)
->>> texts = [[word for word in text if word not in tokens_once]
+>>> from collections import defaultdict
+>>> frequency = defaultdict(int)
+>>> for text in texts:
+>>>     for token in text:
+>>>         frequency[token] += 1
+>>>
+>>> texts = [[token for token in text if frequency[token] > 1]
 >>>          for text in texts]
 >>>
->>> print(texts)
+>>> from pprint import pprint   # pretty-printer
+>>> pprint(texts)
 [['human', 'interface', 'computer'],
  ['survey', 'user', 'computer', 'system', 'response', 'time'],
  ['eps', 'user', 'interface', 'system'],


### PR DESCRIPTION
Uses a `defaultdict` instead of linear scanning through documents to do frequency counting. This takes the complexity down from quadratic to linear, which is important if inexperienced programmers blindly copy-paste this into their own program, and it's more obvious (IMHO) then the `sum` hack used previously.