### PR TITLE
speed up doc2bow by ~40%

### DIFF
--- a/gensim/corpora/dictionary.py
+++ b/gensim/corpora/dictionary.py
@@ -17,7 +17,7 @@ with other dictionary (:func:`Dictionary.merge_with`) etc.
 
 from __future__ import with_statement
 
-from collections import Mapping
+from collections import Mapping, defaultdict
 import sys
 import logging
 import itertools
@@ -124,7 +124,7 @@ class Dictionary(utils.SaveLoad, Mapping):
                 logger.info("adding document #%i to %s", docno, self)
 
             # update Dictionary with the document
-            _ = self.doc2bow(document, allow_update=True) # ignore the result, here we only care about updating token ids
+            self.doc2bow(document, allow_update=True) # ignore the result, here we only care about updating token ids
 
         logger.info("built %s from %i documents (total %i corpus positions)",
                      self, self.num_docs, self.num_pos)
@@ -145,35 +145,35 @@ class Dictionary(utils.SaveLoad, Mapping):
 
         If `allow_update` is **not** set, this function is `const`, aka read-only.
         """
-        result = {}
-        missing = {}
         if isinstance(document, string_types):
             raise TypeError("doc2bow expects an array of unicode tokens on input, not a single string")
-        document = sorted(utils.to_unicode(token) for token in document)
-        # construct (word, frequency) mapping. in python3 this is done simply
-        # using Counter(), but here i use itertools.groupby() for the job
-        for word_norm, group in itertools.groupby(document):
-            frequency = len(list(group)) # how many times does this word appear in the input document
-            tokenid = self.token2id.get(word_norm, None)
-            if tokenid is None:
-                # first time we see this token (~normalized form)
-                if return_missing:
-                    missing[word_norm] = frequency
-                if not allow_update: # if we aren't allowed to create new tokens, continue with the next unique token
-                    continue
-                tokenid = len(self.token2id)
-                self.token2id[word_norm] = tokenid # new id = number of ids made so far; NOTE this assumes there are no gaps in the id sequence!
 
-            # update how many times a token appeared in the document
-            result[tokenid] = frequency
+        # Construct (word, frequency) mapping.
+        counter = defaultdict(int)
+        for w in document:
+            counter[w if isinstance(w, unicode) else unicode(w, 'utf-8')] += 1
+
+        token2id = self.token2id
+        if allow_update or return_missing:
+            missing = {w: freq for w, freq in iteritems(counter)
+                               if w not in token2id}
+            if allow_update:
+                for w in missing:
+                    # new id = number of ids made so far;
+                    # NOTE this assumes there are no gaps in the id sequence!
+                    token2id[w] = len(token2id)
+
+        result = {token2id[w]: freq for w, freq in iteritems(counter)
+                  if w in token2id}
 
         if allow_update:
             self.num_docs += 1
             self.num_pos += len(document)
             self.num_nnz += len(result)
             # increase document count for each unique token that appeared in the document
+            dfs = self.dfs
             for tokenid in iterkeys(result):
-                self.dfs[tokenid] = self.dfs.get(tokenid, 0) + 1
+                dfs[tokenid] = dfs.get(tokenid, 0) + 1
 
         # return tokenids, in ascending id order
         result = sorted(iteritems(result))

--- a/gensim/test/test_corpora_dictionary.py
+++ b/gensim/test/test_corpora_dictionary.py
@@ -92,14 +92,20 @@ class TestDictionary(unittest.TestCase):
 
     def testBuild(self):
         d = Dictionary(self.texts)
-        expected = {0: 2, 1: 2, 2: 2, 3: 2, 4: 2, 5: 3, 6: 2, 7: 3, 8: 2,
-                9: 3, 10: 3, 11: 2}
-        self.assertEqual(d.dfs, expected)
 
-        expected = {'computer': 0, 'eps': 8, 'graph': 10, 'human': 1,
-                'interface': 2, 'minors': 11, 'response': 3, 'survey': 4,
-                'system': 5, 'time': 6, 'trees': 9, 'user': 7}
-        self.assertEqual(d.token2id, expected)
+        # Since we don't specify the order in which dictionaries are built,
+        # we cannot reliably test for the mapping; only the keys and values.
+        expected_keys = list(range(12))
+        expected_values = [2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3]
+        self.assertEqual(sorted(d.dfs.keys()), expected_keys)
+        self.assertEqual(sorted(d.dfs.values()), expected_values)
+
+        expected_keys = sorted(['computer', 'eps', 'graph', 'human',
+                                'interface', 'minors', 'response', 'survey',
+                                'system', 'time', 'trees', 'user'])
+        expected_values = list(range(12))
+        self.assertEqual(sorted(d.token2id.keys()), expected_keys)
+        self.assertEqual(sorted(d.token2id.values()), expected_values)
 
     def testFilter(self):
         d = Dictionary(self.texts)


### PR DESCRIPTION
I found `doc2bow` taking a rather large amount of time. This patch speeds it up by ca. 40% on my data:

* use hash tables, not sorting + grouping
* loops in conditional blocks, not conditional blocks in loops
* cache attribute/method lookups
* inline `to_unicode`

Surprisingly, the final optimization was the most important one. Function call overhead in Python is horrible.