### PR TITLE
Fix docstring for WikiCorpus

### DIFF
--- a/gensim/corpora/wikicorpus.py
+++ b/gensim/corpora/wikicorpus.py
@@ -246,7 +246,7 @@ class WikiCorpus(TextCorpus):
     can stay compressed on disk.
 
     >>> wiki = WikiCorpus('enwiki-20100622-pages-articles.xml.bz2') # create word->word_id mapping, takes almost 8h
-    >>> wiki.saveAsText('wiki_en_vocab200k') # another 8h, creates a file in MatrixMarket format plus file with id->word
+    >>> MmCorpus.serialize('wiki_en_vocab200k', wiki) # another 8h, creates a file in MatrixMarket format plus file with id->word
 
     """
     def __init__(self, fname, processes=None, lemmatize=utils.HAS_PATTERN, dictionary=None, filter_namespaces=('0',)):


### PR DESCRIPTION
After 16h trying to run the commands in the docstring, I got a message saying that 

    AttributeError: 'WikiCorpus' object has no attribute 'saveAsText'

The method does not exist anymore.