### PR TITLE
Move wrappers for external modeling programs into a submodule

### DIFF
--- a/docs/src/apiref.rst
+++ b/docs/src/apiref.rst
@@ -23,7 +23,6 @@ Modules:
     corpora/indexedcorpus
     models/ldamodel
     models/ldamulticore
-    models/ldamallet
     models/lsimodel
     models/tfidfmodel
     models/rpmodel
@@ -35,8 +34,9 @@ Modules:
     models/lda_worker
     models/word2vec
     models/doc2vec
-    models/dtmmodel
     models/phrases
+    models/wrappers/ldamallet
+    models/wrappers/dtmmodel
     similarities/docsim
     similarities/simserver
 

--- a/docs/src/models/wrappers/dtmmodel.rst
+++ b/docs/src/models/wrappers/dtmmodel.rst
@@ -1,7 +1,7 @@
-:mod:`models.dtmmodel` -- Dynamic Topic Models (DTM) and Dynamic Influence Models (DIM)
+:mod:`models.wrappers.dtmmodel` -- Dynamic Topic Models (DTM) and Dynamic Influence Models (DIM)
 =======================================================================================
 
-.. automodule:: gensim.models.dtmmodel
+.. automodule:: gensim.models.wrappers.dtmmodel
     :synopsis: Dynamic Topic Models
     :members:
     :inherited-members:

--- a/docs/src/models/wrappers/ldamallet.rst
+++ b/docs/src/models/wrappers/ldamallet.rst
@@ -1,7 +1,7 @@
-:mod:`models.ldamallet` -- Latent Dirichlet Allocation via Mallet
+:mod:`models.wrappers.ldamallet` -- Latent Dirichlet Allocation via Mallet
 =================================================================
 
-.. automodule:: gensim.models.ldamallet
+.. automodule:: gensim.models.wrappers.ldamallet
     :synopsis: Latent Dirichlet Allocation via Mallet
     :members:
     :inherited-members:

--- a/docs/src/models/wrappers/wrappers.rst
+++ b/docs/src/models/wrappers/wrappers.rst
@@ -1,0 +1,8 @@
+:mod:`models.wrappers` -- Package for transformation models via external programs
+======================================================
+
+.. automodule:: gensim.models.wrappers
+    :synopsis: Package for transformation models via external programs
+    :members:
+    :inherited-members:
+

--- a/gensim/models/__init__.py
+++ b/gensim/models/__init__.py
@@ -6,7 +6,6 @@ bag-of-word counts.
 # bring model classes directly into package namespace, to save some typing
 from .hdpmodel import HdpModel
 from .ldamodel import LdaModel
-from .ldamallet import LdaMallet
 from .lsimodel import LsiModel
 from .tfidfmodel import TfidfModel
 from .rpmodel import RpModel
@@ -14,8 +13,9 @@ from .logentropy_model import LogEntropyModel
 from .word2vec import Word2Vec
 from .doc2vec import Doc2Vec
 from .ldamulticore import LdaMulticore
-from .dtmmodel import DtmModel
 from .phrases import Phrases
+
+from . import wrappers
 
 from gensim import interfaces, utils
 

--- a/gensim/models/wrappers/__init__.py
+++ b/gensim/models/wrappers/__init__.py
@@ -1,0 +1,6 @@
+"""
+This package contains wrappers for other topic modeling programs.
+"""
+
+from .ldamallet import LdaMallet
+from .dtmmodel import DtmModel

--- a/gensim/models/wrappers/dtmmodel.py
+++ b/gensim/models/wrappers/dtmmodel.py
@@ -13,7 +13,7 @@ This module allows for DTM and DIM model estimation from a training corpus.
 
 Example:
 
->>> model = gensim.models.DtmModel('dtm-win64.exe', my_corpus, my_timeslices, num_topics=20, id2word=dictionary)
+>>> model = gensim.models.wrappers.DtmModel('dtm-win64.exe', my_corpus, my_timeslices, num_topics=20, id2word=dictionary)
 
 .. [1] https://code.google.com/p/princeton-statistical-learning/downloads/detail?name=dtm_release-0.8.tgz
 

--- a/gensim/models/wrappers/ldamallet.py
+++ b/gensim/models/wrappers/ldamallet.py
@@ -21,7 +21,7 @@ The wrapped model can NOT be updated with new documents for online training -- u
 
 Example:
 
->>> model = gensim.models.LdaMallet('/Users/kofola/mallet-2.0.7/bin/mallet', corpus=my_corpus, num_topics=20, id2word=dictionary)
+>>> model = gensim.models.wrappers.LdaMallet('/Users/kofola/mallet-2.0.7/bin/mallet', corpus=my_corpus, num_topics=20, id2word=dictionary)
 >>> print model[my_vector]  # print LDA topics of a document
 
 .. [1] http://mallet.cs.umass.edu/
@@ -39,7 +39,7 @@ import numpy
 
 from gensim import utils
 
-logger = logging.getLogger('gensim.models.ldamallet')
+logger = logging.getLogger('gensim.models.wrappers.ldamallet')
 
 
 def read_doctopics(fname, eps=1e-6):

--- a/gensim/test/test_dtm.py
+++ b/gensim/test/test_dtm.py
@@ -35,12 +35,12 @@ class TestDtmModel(unittest.TestCase):
 
     def testDtm(self):
         if self.dtm_path is not None:
-            model = gensim.models.DtmModel(self.dtm_path, self.corpus, self.time_slices, num_topics=2, id2word=self.id2word, model='dtm', initialize_lda=True)
+            model = gensim.models.wrappers.DtmModel(self.dtm_path, self.corpus, self.time_slices, num_topics=2, id2word=self.id2word, model='dtm', initialize_lda=True)
             topics = model.show_topics(topics=2, times=2, topn=10)
 
     def testDim(self):
         if self.dtm_path is not None:
-            model = gensim.models.DtmModel(self.dtm_path, self.corpus, self.time_slices, num_topics=2, id2word=self.id2word, model='fixed', initialize_lda=True)
+            model = gensim.models.wrappers.DtmModel(self.dtm_path, self.corpus, self.time_slices, num_topics=2, id2word=self.id2word, model='fixed', initialize_lda=True)
             topics = model.show_topics(topics=2, times=2, topn=10)
 
 

--- a/gensim/test/test_lee.py
+++ b/gensim/test/test_lee.py
@@ -118,7 +118,7 @@ class TestLeeTest(unittest.TestCase):
     #     corpus = [dictionary.doc2bow(text) for text in corpus2]
 
     #     # initialize an LDA transformation from background corpus
-    #     lda = models.LdaMallet('/Users/kofola/Downloads/mallet-2.0.7/bin/mallet',
+    #     lda = models.wrappers.LdaMallet('/Users/kofola/Downloads/mallet-2.0.7/bin/mallet',
     #         corpus=bg_corpus, id2word=dictionary, num_topics=200, optimize_interval=10)
     #     corpus_lda = lda[corpus]
 

--- a/gensim/test/test_models.py
+++ b/gensim/test/test_models.py
@@ -19,7 +19,8 @@ import numpy
 import scipy.linalg
 
 from gensim.corpora import mmcorpus, Dictionary
-from gensim.models import lsimodel, ldamodel, tfidfmodel, rpmodel, logentropy_model, ldamallet, ldamulticore
+from gensim.models import lsimodel, ldamodel, tfidfmodel, rpmodel, logentropy_model, ldamulticore
+from gensim.models.wrappers import ldamallet
 from gensim import matutils
 
 


### PR DESCRIPTION
This change moves all wrappers for external modeling programs into a submodule.

This is for clarity and organization. I've noticed several mailing list posts with confusion on what these wrappers require, i.e., the external program. Hopefully moving these models into a submodule makes it clearer that they are not 'out-of-the-box' gensim models like the others.