### PR TITLE
Re #256: Fixed warnings.warn() calls in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,8 +66,8 @@ http://api.mongodb.org/python/current/installation.html#osx
         except Exception:
             e = sys.exc_info()[1]
             sys.stdout.write('%s\n' % str(e))
-            warnings.warn(self.warning_message,
-                "Extension modules",
+            warnings.warn(self.warning_message +
+                "Extension modules" +
                 "There was an issue with your platform configuration - see above.")
 
     def build_extension(self, ext):
@@ -77,8 +77,8 @@ http://api.mongodb.org/python/current/installation.html#osx
         except Exception:
             e = sys.exc_info()[1]
             sys.stdout.write('%s\n' % str(e))
-            warnings.warn(self.warning_message,
-                "The %s extension module" % (name,),
+            warnings.warn(self.warning_message +
+                "The %s extension module" % (name,) +
                 "The output above this warning shows how the compilation failed.")
 
     # the following is needed to be able to add numpy's include dirs... without


### PR DESCRIPTION
I ran into the original issue of #256 while fixing Travis CI for PR #284. Tested on 2.7, should work according to 2.6, 3.3. and 3.4 doc. The discussion in #256 turned to another issue, so this PR might not be resolving #256 fully, but there was #257 made for that, right?