### PR TITLE
Refector to use the smart_lib library, if installed

### DIFF
--- a/gensim/corpora/csvcorpus.py
+++ b/gensim/corpora/csvcorpus.py
@@ -16,7 +16,7 @@ import logging
 import csv
 import itertools
 
-from gensim import interfaces
+from gensim import interfaces, utils
 
 logger = logging.getLogger('gensim.corpora.csvcorpus')
 
@@ -42,7 +42,7 @@ class CsvCorpus(interfaces.CorpusABC):
         self.labels = labels
 
         # load the first few lines, to guess the CSV dialect
-        head = ''.join(itertools.islice(open(self.fname), 5))
+        head = ''.join(itertools.islice(utils.smart_open(self.fname), 5))
         self.headers = csv.Sniffer().has_header(head)
         self.dialect = csv.Sniffer().sniff(head)
         logger.info("sniffed CSV delimiter=%r, headers=%s" % (self.dialect.delimiter, self.headers))
@@ -52,7 +52,7 @@ class CsvCorpus(interfaces.CorpusABC):
         Iterate over the corpus, returning one sparse vector at a time.
 
         """
-        reader = csv.reader(open(self.fname), self.dialect)
+        reader = csv.reader(utils.smart_open(self.fname), self.dialect)
         if self.headers:
             next(reader)    # skip the headers
 

--- a/gensim/corpora/sharded_corpus.py
+++ b/gensim/corpora/sharded_corpus.py
@@ -794,7 +794,7 @@ class ShardedCorpus(IndexedCorpus):
         super(ShardedCorpus, self).save(*args, **kwargs)
         #
         # self.reset()
-        # with open(self.output_prefix, 'wb') as pickle_handle:
+        # with smart_open(self.output_prefix, 'wb') as pickle_handle:
         #     cPickle.dump(self, pickle_handle)
 
     @classmethod

--- a/gensim/matutils.py
+++ b/gensim/matutils.py
@@ -435,7 +435,7 @@ class MmWriter(object):
         self.fname = fname
         if fname.endswith(".gz") or fname.endswith('.bz2'):
             raise NotImplementedError("compressed output not supported with MmWriter")
-        self.fout = open(self.fname, 'wb+') # open for both reading and writing
+        self.fout = utils.smart_open(self.fname, 'wb+') # open for both reading and writing
         self.headers_written = False
 
 
@@ -671,7 +671,7 @@ class MmReader(object):
         if offset == -1:
             return []
         if isinstance(self.input, string_types):
-            fin = open(self.input)
+            fin = utils.smart_open(self.input)
         else:
             fin = self.input
 

--- a/gensim/models/hdpmodel.py
+++ b/gensim/models/hdpmodel.py
@@ -463,16 +463,16 @@ class HdpModel(interfaces.TransformationABC):
         probable words for `topics` number of topics to log.
         Set `topics=-1` to print all topics."""
         return self.show_topics(topics=topics, topn=topn, log=True)
-        
+
     def show_topics(self, topics=20, topn=20, log=False, formatted=True):
         """
         Print the `topN` most probable words for `topics` number of topics.
         Set `topics=-1` to print all topics.
 
-        Set `formatted=True` to return the topics as a list of strings, or 
+        Set `formatted=True` to return the topics as a list of strings, or
         `False` as lists of (weight, word) pairs.
 
-        """        
+        """
         if not self.m_status_up_to_date:
             self.update_expectations()
         betas = self.m_lambda + self.m_eta
@@ -499,7 +499,7 @@ class HdpModel(interfaces.TransformationABC):
             logger.error("cannot store options without having specified an output directory")
             return
         fname = '%s/options.dat' % self.outputdir
-        with open(fname, 'wb') as fout:
+        with utils.smart_open(fname, 'wb') as fout:
             fout.write('tau: %s\n' % str(self.m_tau - 1))
             fout.write('chunksize: %s\n' % str(self.chunksize))
             fout.write('var_converge: %s\n' % str(self.m_var_converge))

--- a/gensim/models/wrappers/ldavowpalwabbit.py
+++ b/gensim/models/wrappers/ldavowpalwabbit.py
@@ -276,12 +276,12 @@ class LdaVowpalWabbit(utils.SaveLoad):
             # variable before serialising this object - keeps all data
             # self contained within a single serialised file
             LOG.debug("Reading model bytes from '%s'", self._model_filename)
-            with open(self._model_filename, 'rb') as fhandle:
+            with utils.smart_open(self._model_filename, 'rb') as fhandle:
                 self._model_data = fhandle.read()
 
         if os.path.exists(self._topics_filename):
             LOG.debug("Reading topic bytes from '%s'", self._topics_filename)
-            with open(self._topics_filename, 'rb') as fhandle:
+            with utils.smart_open(self._topics_filename, 'rb') as fhandle:
                 self._topics_data = fhandle.read()
 
         if 'ignore' not in kwargs:
@@ -299,13 +299,13 @@ class LdaVowpalWabbit(utils.SaveLoad):
             # Vowpal Wabbit operates on its own binary model file - deserialise
             # to file at load time, making it immediately ready for use
             LOG.debug("Writing model bytes to '%s'", lda_vw._model_filename)
-            with open(lda_vw._model_filename, 'wb') as fhandle:
+            with utils.smart_open(lda_vw._model_filename, 'wb') as fhandle:
                 fhandle.write(lda_vw._model_data)
             lda_vw._model_data = None # no need to keep in memory after this
 
         if lda_vw._topics_data:
             LOG.debug("Writing topic bytes to '%s'", lda_vw._topics_filename)
-            with open(lda_vw._topics_filename, 'wb') as fhandle:
+            with utils.smart_open(lda_vw._topics_filename, 'wb') as fhandle:
                 fhandle.write(lda_vw._topics_data)
             lda_vw._topics_data = None
 
@@ -385,7 +385,7 @@ class LdaVowpalWabbit(utils.SaveLoad):
         topics = numpy.zeros((self.num_topics, self.num_terms),
                              dtype=numpy.float32)
 
-        with open(self._topics_filename) as topics_file:
+        with utils.smart_open(self._topics_filename) as topics_file:
             found_options = False
 
             for line in topics_file:
@@ -427,7 +427,7 @@ class LdaVowpalWabbit(utils.SaveLoad):
         predictions = numpy.zeros((corpus_size, self.num_topics),
                                   dtype=numpy.float32)
 
-        with open(self._predict_filename) as fhandle:
+        with utils.smart_open(self._predict_filename) as fhandle:
             for i, line in enumerate(fhandle):
                 predictions[i, :] = line.split()
 
@@ -514,7 +514,7 @@ def write_corpus_as_vw(corpus, filename):
     LOG.debug("Writing corpus to: %s", filename)
 
     corpus_size = 0
-    with open(filename, 'w') as corpus_file:
+    with utils.smart_open(filename, 'wb') as corpus_file:
         for line in corpus_to_vw(corpus):
             print(line, file=corpus_file)
             corpus_size += 1

--- a/setup.py
+++ b/setup.py
@@ -160,6 +160,7 @@ setup(
     ],
 
     extras_require={
+        'smart_open': ['smart_open >= 1.1.0'],
         'distributed': ['Pyro4 >= 4.27'],
     },
 

--- a/setup.py
+++ b/setup.py
@@ -157,10 +157,10 @@ setup(
         'numpy >= 1.3',
         'scipy >= 0.7.0',
         'six >= 1.2.0',
+        'smart_open >= 1.2.0',
     ],
 
     extras_require={
-        'smart_open': ['smart_open >= 1.1.0'],
         'distributed': ['Pyro4 >= 4.27'],
     },
 


### PR DESCRIPTION
This pull request makes gensim prefer and use the standalone [smart_open library](https://github.com/piskvorky/smart_open), rather than gensim.utils.smart_open.

This change should be fully backward compatible -- the standalone lib offers strictly more functionality (and tests) than the current `gensim.utils.smart_open` implementation.

If smart_open lib is not installed, it's not an error, gensim just falls backs to the current `gensim.utils.smart_open` implementation.