### PR TITLE
Trivial changes

### DIFF
--- a/gensim/__init__.py
+++ b/gensim/__init__.py
@@ -3,7 +3,7 @@ This package contains interfaces and functionality to compute pair-wise document
 similarities within a corpus of documents.
 """
 
-from gensim import utils, matutils, interfaces, corpora, models, similarities
+from gensim import parsing, matutils, interfaces, corpora, models, similarities
 import logging
 
 try:

--- a/gensim/utils.py
+++ b/gensim/utils.py
@@ -169,8 +169,9 @@ def copytree_hardlink(source, dest):
 
 def tokenize(text, lowercase=False, deacc=False, errors="strict", to_lower=False, lower=False):
     """
-    Iteratively yield tokens as unicode strings, optionally also lowercasing them
-    and removing accent marks.
+    Iteratively yield tokens as unicode strings, removing accent marks
+    and optionally lowercasing the unidoce string by assigning True 
+    to one of the parameters, lowercase, to_lower, or lower.
 
     Input text may be either unicode or utf8-encoded byte string.
 
@@ -195,7 +196,7 @@ def simple_preprocess(doc, deacc=False, min_len=2, max_len=15):
     """
     Convert a document into a list of tokens.
 
-    This lowercases, tokenizes, stems, normalizes etc. -- the output are final
+    This lowercases, tokenizes, de-accents (optional). -- the output are final
     tokens = unicode strings, that won't be processed any further.
 
     """


### PR DESCRIPTION
I found that gensim already has some useful tools for preprocessing and tokenizing and I was using external librarys for the same purpose while I'm only focusing heavier modules in gensim. However, the usage was not clear and led me to read the codes in the module, utils and parsing, and put some words  on them.

I wonder if there's any specific reason for not loading the module 'parsing' while importing 'utils' under the top module 'gensim'. I think it gives better usability to load 'parsing' instead of 'utils', as users can access namespaces in 'utils' in both ways of 'gensim.utils' and 'gensim.parsing.utils', as well as having the package 'gensim.parsing' without importing it explicitly. Of course it won't affect to users already put the namespace 'gensim.utils' in their codes.