### PR TITLE
Fixes to string/byte handling with python 3 and smart_open.

### DIFF
--- a/gensim/models/wrappers/ldavowpalwabbit.py
+++ b/gensim/models/wrappers/ldavowpalwabbit.py
@@ -391,7 +391,7 @@ class LdaVowpalWabbit(utils.SaveLoad):
 
             for line in topics_file:
                 if not found_options:
-                    if line.startswith('options:'):
+                    if line.startswith(b'options:'):
                         found_options = True
                     continue
 
@@ -517,7 +517,7 @@ def write_corpus_as_vw(corpus, filename):
     corpus_size = 0
     with utils.smart_open(filename, 'wb') as corpus_file:
         for line in corpus_to_vw(corpus):
-            print(line, file=corpus_file)
+            corpus_file.write(line.encode('utf-8') + b'\n')
             corpus_size += 1
 
     return corpus_size


### PR DESCRIPTION
This fixes an issue with using smart_open in the ldavowpalwabbit wrapper in python 3.

smart_open reads/writes as bytes rather than string, so data being
written or read is now of the expected type (i.e. string encoded as bytes before writing, and assumed to be bytes rather than string when being read).

Tested with python 2.6, 2.7, 3.4.