### PR TITLE
Update word2vec.py

### DIFF
--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -606,7 +606,7 @@ class Word2Vec(utils.SaveLoad):
                     result.syn0[line_no] = fromstring(fin.read(binary_len), dtype=REAL)
             else:
                 for line_no, line in enumerate(fin):
-                    parts = utils.to_unicode(line).split()
+                    parts = utils.to_unicode(line.rstrip()).split(" ")
                     if len(parts) != layer1_size + 1:
                         raise ValueError("invalid vector on line %s (is this really the text format?)" % (line_no))
                     word, weights = parts[0], list(map(REAL, parts[1:]))


### PR DESCRIPTION
Python's split, when used with no parameter, uses 'space, tab, newline, return, formfeed' to split a string. Mikolov's word2vec, however, may produce words that include non-whitespace spaces. Explicitly putting whitespace, and eliminating the newline, gets rid of annoying errors.