### PR TITLE
Update word2vec.py

### DIFF
--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -606,7 +606,7 @@ class Word2Vec(utils.SaveLoad):
                     result.syn0[line_no] = fromstring(fin.read(binary_len), dtype=REAL)
             else:
                 for line_no, line in enumerate(fin):
-                    parts = utils.to_unicode(line).split()
+                    parts = utils.to_unicode(line.rstrip(),errors="ignore").split(" ")
                     if len(parts) != layer1_size + 1:
                         raise ValueError("invalid vector on line %s (is this really the text format?)" % (line_no))
                     word, weights = parts[0], list(map(REAL, parts[1:]))

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -555,7 +555,7 @@ class Word2Vec(utils.SaveLoad):
 
 
     @classmethod
-    def load_word2vec_format(cls, fname, fvocab=None, binary=False, norm_only=True):
+    def load_word2vec_format(cls, fname, fvocab=None, binary=False, norm_only=True,errors="strict"):
         """
         Load the input-hidden weight matrix from the original C word2vec-tool format.
 
@@ -606,7 +606,7 @@ class Word2Vec(utils.SaveLoad):
                     result.syn0[line_no] = fromstring(fin.read(binary_len), dtype=REAL)
             else:
                 for line_no, line in enumerate(fin):
-                    parts = utils.to_unicode(line.rstrip(),errors="ignore").split(" ")
+                    parts = utils.to_unicode(line.rstrip(),errors=errors).split(" ")
                     if len(parts) != layer1_size + 1:
                         raise ValueError("invalid vector on line %s (is this really the text format?)" % (line_no))
                     word, weights = parts[0], list(map(REAL, parts[1:]))


### PR DESCRIPTION
Hi Radim,

No tabs or new lines are allowed in a word. So a split based on whitespace is enough (after a newline removal with rstrip). I added the whitespace with a b prefix as you suggested for python 3 compatibility(have not tested with python 3)

I also added errors="ignore" because I had errors like UnicodeDecodeError: 'utf8' codec can't decode byte 0xe2 in position 97: invalid continuation byte,(again this is with output from word2vec.)

I tested the code with my data file, and everything worked fine. 