### PR TITLE
Set default pickle protocol version to 2

### DIFF
--- a/gensim/utils.py
+++ b/gensim/utils.py
@@ -831,8 +831,13 @@ def smart_extension(fname, ext):
     return fname
 
 
-def pickle(obj, fname, protocol=_pickle.HIGHEST_PROTOCOL):
-    """Pickle object `obj` to file `fname`."""
+def pickle(obj, fname, protocol=2):
+    """Pickle object `obj` to file `fname`.
+
+    `protocol` defaults to 2 so pickled objects are compatible across
+    Python 2.x and 3.x.
+
+    """
     with smart_open(fname, 'wb') as fout: # 'b' for binary, needed on Windows
         _pickle.dump(obj, fout, protocol=protocol)
 


### PR DESCRIPTION
To make pickled objects compatible across Python 2 and 3, max pickle protocol version should be set at 2.

I'll file another PR for specifying pickle version as option in`utils.SaveLoad.save(...)`, so user can still set their desired pickle protocol.

For full report see issue #359. 