### PR TITLE
Prune vocab

### DIFF
--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -587,8 +587,8 @@ class Doc2Vec(Word2Vec):
         for document_no, document in enumerate(documents):
             if document_no % progress_per == 0:
                 interval_rate = (total_words - interval_count) / (default_timer() - interval_start)
-                logger.info("PROGRESS: at example #%i, processed %i words (%i/s), %i word types, %i tags" %
-                            (document_no, total_words, interval_rate, len(vocab), len(self.docvecs)))
+                logger.info("PROGRESS: at example #%i, processed %i words (%i/s), %i word types, %i tags",
+                            document_no, sum(itervalues(vocab)) + total_words, interval_rate, len(vocab), len(self.docvecs))
                 interval_start = default_timer()
                 interval_count = total_words
             document_length = len(document.words)
@@ -604,8 +604,8 @@ class Doc2Vec(Word2Vec):
                 min_reduce += 1
 
         total_words += sum(itervalues(vocab))
-        logger.info("collected %i word types and %i unique tags from a corpus of %i examples and %i words" %
-                    (len(vocab), len(self.docvecs), document_no + 1, total_words))
+        logger.info("collected %i word types and %i unique tags from a corpus of %i examples and %i words",
+                    len(vocab), len(self.docvecs), document_no + 1, total_words)
         self.corpus_count = document_no + 1
         self.raw_vocab = vocab
 

--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -688,7 +688,7 @@ class Doc2Vec(Word2Vec):
             segments.append('s%g' % self.sample)
         if self.workers > 1:
             segments.append('t%d' % self.workers)
-        return 'Doc2Vec(%s)' % ','.join(segments)
+        return '%s(%s)' % (self.__class__.__name__, ','.join(segments))
 
 
 class TaggedBrownCorpus(object):

--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -477,8 +477,8 @@ class Doctag(namedtuple('Doctag', 'index, word_count, doc_count')):
 class Doc2Vec(Word2Vec):
     """Class for training, using and evaluating neural networks described in http://arxiv.org/pdf/1405.4053v2.pdf"""
     def __init__(self, documents=None, size=300, alpha=0.025, window=8, min_count=5,
-                 sample=0, seed=1, workers=1, min_alpha=0.0001, dm=1, hs=1, negative=0,
-                 dbow_words=0, dm_mean=0, dm_concat=0, dm_tag_count=1,
+                 max_vocab_size=10000000, sample=0, seed=1, workers=1, min_alpha=0.0001,
+                 dm=1, hs=1, negative=0, dbow_words=0, dm_mean=0, dm_concat=0, dm_tag_count=1,
                  docvecs=None, docvecs_mapfile=None, comment=None, **kwargs):
         """
         Initialize the model from an iterable of `documents`. Each document is a
@@ -505,6 +505,9 @@ class Doc2Vec(Word2Vec):
 
         `min_count` = ignore all words with total frequency lower than this.
 
+        `max_vocab_size` = limit RAM during vocabulary building; if there are more unique
+        words than this, then prune the infrequent ones. Set to `None` for no limit.
+
         `sample` = threshold for configuring which higher-frequency words are randomly downsampled;
                 default is 0 (off), useful value is 1e-5.
 
@@ -530,10 +533,11 @@ class Doc2Vec(Word2Vec):
         doc-vector training; default is 0 (faster training of doc-vectors only).
 
         """
-        super(Doc2Vec, self).__init__(size=size, alpha=alpha, window=window, min_count=min_count,
-                                      sample=sample, seed=seed, workers=workers, min_alpha=min_alpha,
-                                      sg=(1+dm) % 2, hs=hs, negative=negative, cbow_mean=dm_mean,
-                                      null_word=dm_concat, **kwargs)
+        super(Doc2Vec, self).__init__(
+            size=size, alpha=alpha, window=window, min_count=min_count, max_vocab_size=max_vocab_size,
+            sample=sample, seed=seed, workers=workers, min_alpha=min_alpha,
+            sg=(1+dm) % 2, hs=hs, negative=negative, cbow_mean=dm_mean,
+            null_word=dm_concat, **kwargs)
         self.dbow_words = dbow_words
         self.dm_concat = dm_concat
         self.dm_tag_count = dm_tag_count

--- a/gensim/models/phrases.py
+++ b/gensim/models/phrases.py
@@ -152,7 +152,7 @@ class Phrases(interfaces.TransformationABC):
                 vocab[word] += 1
 
             if len(vocab) > max_vocab_size:
-                prune_vocab(vocab, min_reduce)
+                utils.prune_vocab(vocab, min_reduce)
                 min_reduce += 1
 
         logger.info("collected %i word types from a corpus of %i words (unigram + bigrams) and %i sentences" %
@@ -242,20 +242,6 @@ class Phrases(interfaces.TransformationABC):
                 new_s.append(last_token)
 
         return [utils.to_unicode(w) for w in new_s]
-
-
-def prune_vocab(vocab, min_reduce):
-    """
-    Remove all entries from the `vocab` dictionary with count smaller than `min_reduce`.
-    Modifies `vocab` in place.
-
-    """
-    old_len = len(vocab)
-    for w in list(vocab):  # make a copy of dict's keys
-        if vocab[w] <= min_reduce:
-            del vocab[w]
-    logger.info("pruned out %i tokens with count <=%i (before %i, after %i)" %
-        (old_len - len(vocab), min_reduce, old_len, len(vocab)))
 
 
 if __name__ == '__main__':

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -485,8 +485,8 @@ class Word2Vec(utils.SaveLoad):
         vocab = defaultdict(int)
         for sentence_no, sentence in enumerate(sentences):
             if sentence_no % progress_per == 0:
-                logger.info("PROGRESS: at sentence #%i, processed %i words and %i word types" %
-                            (sentence_no, total_words, len(vocab)))
+                logger.info("PROGRESS: at sentence #%i, processed %i words, keeping %i word types",
+                            sentence_no, sum(itervalues(vocab)) + total_words, len(vocab))
             for word in sentence:
                 vocab[word] += 1
 
@@ -495,8 +495,8 @@ class Word2Vec(utils.SaveLoad):
                 min_reduce += 1
 
         total_words += sum(itervalues(vocab))
-        logger.info("collected %i word types from a corpus of %i words and %i sentences" %
-                    (len(vocab), total_words, sentence_no + 1))
+        logger.info("collected %i word types from a corpus of %i words and %i sentences",
+                    len(vocab), total_words, sentence_no + 1)
         self.corpus_count = sentence_no + 1
         self.raw_vocab = vocab
 

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -495,7 +495,6 @@ class Word2Vec(utils.SaveLoad):
                 min_reduce += 1
 
         total_words += sum(itervalues(vocab))
-
         logger.info("collected %i word types from a corpus of %i words and %i sentences" %
                     (len(vocab), total_words, sentence_no + 1))
         self.corpus_count = sentence_no + 1

--- a/gensim/test/test_doc2vec.py
+++ b/gensim/test/test_doc2vec.py
@@ -14,10 +14,8 @@ import logging
 import unittest
 import os
 import tempfile
-import itertools
-import bz2
-from six import iteritems, iterkeys
-from six.moves import xrange, zip as izip
+
+from six.moves import zip as izip
 from collections import namedtuple
 
 import numpy as np
@@ -25,7 +23,7 @@ import numpy as np
 from gensim import utils, matutils
 from gensim.models import doc2vec
 
-module_path = os.path.dirname(__file__) # needed because sample data files are located in the same folder
+module_path = os.path.dirname(__file__)  # needed because sample data files are located in the same folder
 datapath = lambda fname: os.path.join(module_path, 'test_data', fname)
 
 
@@ -39,7 +37,7 @@ class DocsLeeCorpus(object):
     def __iter__(self):
         with open(datapath('lee_background.cor')) as f:
             for i, line in enumerate(f):
-                yield doc2vec.TaggedDocument(utils.simple_preprocess(line),[self._tag(i)])
+                yield doc2vec.TaggedDocument(utils.simple_preprocess(line), [self._tag(i)])
 
 list_corpus = list(DocsLeeCorpus())
 
@@ -55,7 +53,7 @@ sentences = [
         ['graph', 'minors', 'survey']
     ]
 
-sentences = [doc2vec.TaggedDocument(words,[i]) for i, words in enumerate(sentences)]
+sentences = [doc2vec.TaggedDocument(words, [i]) for i, words in enumerate(sentences)]
 
 
 def testfile():
@@ -87,9 +85,9 @@ class TestDoc2VecModel(unittest.TestCase):
 
         model = doc2vec.Doc2Vec(min_count=1)
         model.build_vocab(corpus)
-        self.assertEqual(len(model.docvecs.doctag_syn0),300)
-        self.assertEqual(model.docvecs[0].shape,(300,))
-        self.assertRaises(KeyError,model.__getitem__,'_*0')
+        self.assertEqual(len(model.docvecs.doctag_syn0), 300)
+        self.assertEqual(model.docvecs[0].shape, (300,))
+        self.assertRaises(KeyError, model.__getitem__, '_*0')
 
     def test_string_doctags(self):
         """Test doc2vec doctag alternatives"""
@@ -99,10 +97,10 @@ class TestDoc2VecModel(unittest.TestCase):
 
         model = doc2vec.Doc2Vec(min_count=1)
         model.build_vocab(corpus)
-        self.assertEqual(len(model.docvecs.doctag_syn0),300)
-        self.assertEqual(model.docvecs[0].shape,(300,))
-        self.assertEqual(model.docvecs['_*0'].shape,(300,))
-        self.assertTrue(all(model.docvecs['_*0']==model.docvecs[0]))
+        self.assertEqual(len(model.docvecs.doctag_syn0), 300)
+        self.assertEqual(model.docvecs[0].shape, (300,))
+        self.assertEqual(model.docvecs['_*0'].shape, (300,))
+        self.assertTrue(all(model.docvecs['_*0'] == model.docvecs[0]))
         self.assertTrue(max(d.index for d in model.docvecs.doctags.values()) < len(model.docvecs.doctag_syn0))
 
     def test_empty_errors(self):
@@ -124,7 +122,7 @@ class TestDoc2VecModel(unittest.TestCase):
         self.assertTrue(fire1 in [match[0] for match in sims_to_infer])
 
         # fire8 should be top20 close to fire1
-        sims = model.docvecs.most_similar(fire1,topn=20)
+        sims = model.docvecs.most_similar(fire1, topn=20)
         self.assertTrue(fire2 in [match[0] for match in sims])
 
         # same sims should appear in lookup by vec as by index
@@ -135,10 +133,10 @@ class TestDoc2VecModel(unittest.TestCase):
         self.assertTrue(np.allclose(list(zip(*sims))[1], list(zip(*sims2))[1]))  # close-enough dists
 
         # tennis doc should be out-of-place among fire news
-        self.assertEqual(model.docvecs.doesnt_match([fire1, tennis1, fire2]), tennis1) 
+        self.assertEqual(model.docvecs.doesnt_match([fire1, tennis1, fire2]), tennis1)
 
         # fire docs should be closer than fire-tennis
-        self.assertTrue(model.docvecs.similarity(fire1,fire2) > model.docvecs.similarity(fire1,tennis1))
+        self.assertTrue(model.docvecs.similarity(fire1, fire2) > model.docvecs.similarity(fire1, tennis1))
 
     def test_training(self):
         """Test doc2vec training."""
@@ -159,19 +157,19 @@ class TestDoc2VecModel(unittest.TestCase):
         model = doc2vec.Doc2Vec(list_corpus, dm=0, hs=1, negative=0, min_count=2, iter=20)
         self.model_sanity(model)
 
-    def test_dmm_hs(self): 
+    def test_dmm_hs(self):
         """Test DM/mean doc2vec training."""
         model = doc2vec.Doc2Vec(list_corpus, dm=1, dm_mean=1, size=24, window=4, hs=1, negative=0,
                                 min_count=2, iter=20)
         self.model_sanity(model)
 
-    def test_dms_hs(self): 
+    def test_dms_hs(self):
         """Test DM/sum doc2vec training."""
         model = doc2vec.Doc2Vec(list_corpus, dm=1, dm_mean=0, size=24, window=4, hs=1, negative=0,
                                 min_count=2, iter=20)
         self.model_sanity(model)
 
-    def test_dmc_hs(self): 
+    def test_dmc_hs(self):
         """Test DM/concatenate doc2vec training."""
         model = doc2vec.Doc2Vec(list_corpus, dm=1, dm_concat=1, size=24, window=4, hs=1, negative=0,
                                 min_count=2, iter=20)
@@ -182,24 +180,24 @@ class TestDoc2VecModel(unittest.TestCase):
         model = doc2vec.Doc2Vec(list_corpus, dm=0, hs=0, negative=10, min_count=2, iter=20)
         self.model_sanity(model)
 
-    def test_dmm_neg(self): 
+    def test_dmm_neg(self):
         """Test DM/mean doc2vec training."""
         model = doc2vec.Doc2Vec(list_corpus, dm=1, dm_mean=1, size=24, window=4, hs=0, negative=10,
                                 min_count=2, iter=20)
         self.model_sanity(model)
 
-    def test_dms_neg(self): 
+    def test_dms_neg(self):
         """Test DM/sum doc2vec training."""
         model = doc2vec.Doc2Vec(list_corpus, dm=1, dm_mean=0, size=24, window=4, hs=0, negative=10,
                                 min_count=2, iter=20)
         self.model_sanity(model)
 
-    def test_dmc_neg(self): 
+    def test_dmc_neg(self):
         """Test DM/concatenate doc2vec training."""
         model = doc2vec.Doc2Vec(list_corpus, dm=1, dm_concat=1, size=24, window=4, hs=0, negative=10,
                                 min_count=2, iter=20)
-        self.model_sanity(model)        
-        
+        self.model_sanity(model)
+
     def test_parallel(self):
         """Test doc2vec parallel training."""
         if doc2vec.FAST_VERSION < 0:  # don't test the plain NumPy version for parallelism (too slow)
@@ -254,19 +252,19 @@ class TestDoc2VecModel(unittest.TestCase):
 class ConcatenatedDoc2Vec(object):
     """
     Concatenation of multiple models for reproducing the Paragraph Vectors paper.
-    Models must have exactly-matching vocabulary and document IDs. (Models should 
+    Models must have exactly-matching vocabulary and document IDs. (Models should
     be trained separately; this wrapper just returns concatenated results.)
     """
     def __init__(self, models):
         self.models = models
-        if hasattr(models[0],'docvecs'): 
+        if hasattr(models[0], 'docvecs'):
             self.docvecs = ConcatenatedDocvecs([model.docvecs for model in models])
 
     def __getitem__(self, token):
         return np.concatenate([model[token] for model in self.models])
 
     def infer_vector(self, document, alpha=0.1, min_alpha=0.0001, steps=5):
-        return np.concatenate([model.infer_vector(document,alpha,min_alpha,steps) for model in self.models])
+        return np.concatenate([model.infer_vector(document, alpha, min_alpha, steps) for model in self.models])
 
     def train(self, ignored):
         pass  # train subcomponents individually
@@ -274,17 +272,17 @@ class ConcatenatedDoc2Vec(object):
 class ConcatenatedDocvecs(object):
     def __init__(self, models):
         self.models = models
-    
-    def __getitem__(self, token):
-        return np.concatenate([model[token] for model in self.models])        
 
-    
-SentimentDocument = namedtuple('SentimentDocument','words tags split sentiment')
+    def __getitem__(self, token):
+        return np.concatenate([model[token] for model in self.models])
+
+
+SentimentDocument = namedtuple('SentimentDocument', 'words tags split sentiment')
 
 
 def read_su_sentiment_rotten_tomatoes(dirname, lowercase=True):
     """
-    Read and return documents from the Stanford Sentiment Treebank 
+    Read and return documents from the Stanford Sentiment Treebank
     corpus (Rotten Tomatoes reviews), from http://nlp.Stanford.edu/sentiment/
 
     Initialize the corpus from a given directory, where
@@ -348,7 +346,7 @@ def read_su_sentiment_rotten_tomatoes(dirname, lowercase=True):
             if lowercase:
                 words = [word.lower() for word in words]
             (sentence_id, split_i) = info_by_sentence.get(text, (None, 0))
-            split = [None,'train','test','dev'][split_i]
+            split = [None, 'train', 'test', 'dev'][split_i]
             phrases[id] = SentimentPhrase(words, [id], split, sentiment, sentence_id)
 
     assert len([phrase for phrase in phrases if phrase.sentence_id is not None]) == len(info_by_sentence)  # all

--- a/gensim/test/test_doc2vec.py
+++ b/gensim/test/test_doc2vec.py
@@ -128,7 +128,7 @@ class TestDoc2VecModel(unittest.TestCase):
         # same sims should appear in lookup by vec as by index
         doc0_vec = model.docvecs[fire1]
         sims2 = model.docvecs.most_similar(positive=[doc0_vec], topn=21)
-        sims2 = sims2[1:] # ignore first element of sims2, which is doc itself
+        sims2 = [(id, sim) for id, sim in sims2 if id != fire1]  # ignore the doc itself
         self.assertEqual(list(zip(*sims))[0], list(zip(*sims2))[0])  # same doc ids
         self.assertTrue(np.allclose(list(zip(*sims))[1], list(zip(*sims2))[1]))  # close-enough dists
 

--- a/gensim/test/test_word2vec.py
+++ b/gensim/test/test_word2vec.py
@@ -115,8 +115,7 @@ class TestWord2VecModel(unittest.TestCase):
         model.build_vocab(corpus)
         self.assertTrue(len(model.vocab) == 6981)
         # with min_count=1, we're not throwing away anything, so make sure the word counts add up to be the entire corpus
-        self.assertEqual(sum(v.count for v in model.vocab.values()),
-                         total_words)
+        self.assertEqual(sum(v.count for v in model.vocab.values()), total_words)
         # make sure the binary codes are correct
         numpy.allclose(model.vocab['the'].code, [1, 1, 0, 0])
 

--- a/gensim/utils.py
+++ b/gensim/utils.py
@@ -1075,3 +1075,21 @@ def mock_data(n_items=1000, dim=1000, prob_nnz=0.5, lam=1.0):
     data = [mock_data_row(dim=dim, prob_nnz=prob_nnz, lam=lam)
             for _ in xrange(n_items)]
     return data
+
+
+def prune_vocab(vocab, min_reduce):
+    """
+    Remove all entries from the `vocab` dictionary with count smaller than `min_reduce`.
+
+    Modifies `vocab` in place, returns the sum of all counts that were pruned.
+
+    """
+    result = 0
+    old_len = len(vocab)
+    for w in list(vocab):  # make a copy of dict's keys
+        if vocab[w] <= min_reduce:
+            result += vocab[w]
+            del vocab[w]
+    logger.info("pruned out %i tokens with count <=%i (before %i, after %i)",
+                old_len - len(vocab), min_reduce, old_len, len(vocab))
+    return result


### PR DESCRIPTION
Use less memory during word2vec and doc2vec vocabulary building.

Refactored Phrases to use the same function for pruning the count dictionary, which was moved under `utils.prune_vocab`.

The main win comes from keeping raw counts in a plain dict (defaultdict) and only creating the expensive Vocab objects for words with count >= `min_count`.

The additional option of trimming the defaultdict to be <= `max_vocab_size` is likely not even necessary (I set the default `max_vocab_size=10,000,000`, which consumes only about 1GB of RAM).

I also removed the stderr flushes (belongs to logging, not core gensim -- logs can go to files etc, stderr is just incidental) and made some minor PEP8 fixes.