### PR TITLE
Fix issue #387: summarization on short texts

### DIFF
--- a/gensim/summarization/summarizer.py
+++ b/gensim/summarization/summarizer.py
@@ -144,13 +144,14 @@ def summarize_corpus(corpus, ratio=0.2):
     """
     hashable_corpus = _build_hasheable_corpus(corpus)
 
+    # If the corpus is empty, the function ends.
+    if len(corpus) == 0:
+        logger.warning("Input corpus is empty.")
+        return
+
     # Warns the user if there are too few documents.
     if len(corpus) < INPUT_MIN_LENGTH:
         logger.warning("Input corpus is expected to have at least " + str(INPUT_MIN_LENGTH) + " documents.")
-
-    # If the corpus is empty, the function ends.
-    if len(corpus) == 0:
-        return
 
     graph = _build_graph(hashable_corpus)
     _set_graph_edge_weights(graph)
@@ -186,13 +187,14 @@ def summarize(text, ratio=0.2, word_count=None, split=False):
     # Gets a list of processed sentences.
     sentences = _clean_text_by_sentences(text)
 
+    # If no sentence could be identified, the function ends.
+    if len(sentences) == 0:
+        logger.warning("Input text is empty.")
+        return
+
     # Warns if the text is too short.
     if len(sentences) < INPUT_MIN_LENGTH:
         logger.warning("Input text is expected to have at least " + str(INPUT_MIN_LENGTH) + " sentences.")
-
-    # If no sentence could be identified, the function ends.
-    if len(sentences) == 0:
-        return
 
     corpus = _build_corpus(sentences)
 

--- a/gensim/summarization/summarizer.py
+++ b/gensim/summarization/summarizer.py
@@ -3,6 +3,7 @@
 #
 # Licensed under the GNU LGPL v2.1 - http://www.gnu.org/licenses/lgpl.html
 
+import logging
 from gensim.summarization.pagerank_weighted import pagerank_weighted as _pagerank
 from gensim.summarization.textcleaner import clean_text_by_sentences as _clean_text_by_sentences
 from gensim.summarization.commons import build_graph as _build_graph
@@ -13,8 +14,10 @@ from scipy.sparse import csr_matrix
 from math import log10 as _log10
 from six.moves import xrange
 
+
 INPUT_MIN_LENGTH = 10
 
+logger = logging.getLogger(__name__)
 
 def _set_graph_edge_weights(graph):
     documents = graph.nodes()
@@ -140,8 +143,9 @@ def summarize_corpus(corpus, ratio=0.2):
     """
     hashable_corpus = _build_hasheable_corpus(corpus)
 
+    # Warns the user if there are too few documents.
     if len(corpus) < INPUT_MIN_LENGTH:
-        raise RuntimeError("Input corpus must have at least " + str(INPUT_MIN_LENGTH) + " documents.")
+        logger.warning("Input corpus is expected to have at least " + str(INPUT_MIN_LENGTH) + " documents.")
 
     graph = _build_graph(hashable_corpus)
     _set_graph_edge_weights(graph)
@@ -177,8 +181,9 @@ def summarize(text, ratio=0.2, word_count=None, split=False):
     # Gets a list of processed sentences.
     sentences = _clean_text_by_sentences(text)
 
+    # Warns if the text is too short.
     if len(sentences) < INPUT_MIN_LENGTH:
-        raise RuntimeError("Input text must have at least " + str(INPUT_MIN_LENGTH) + " sentences.")
+        logger.warning("Input text is expected to have at least " + str(INPUT_MIN_LENGTH) + " sentences.")
 
     corpus = _build_corpus(sentences)
 

--- a/gensim/summarization/summarizer.py
+++ b/gensim/summarization/summarizer.py
@@ -19,6 +19,7 @@ INPUT_MIN_LENGTH = 10
 
 logger = logging.getLogger(__name__)
 
+
 def _set_graph_edge_weights(graph):
     documents = graph.nodes()
     weights = _bm25_weights(documents)
@@ -147,6 +148,10 @@ def summarize_corpus(corpus, ratio=0.2):
     if len(corpus) < INPUT_MIN_LENGTH:
         logger.warning("Input corpus is expected to have at least " + str(INPUT_MIN_LENGTH) + " documents.")
 
+    # If the corpus is empty, the function ends.
+    if len(corpus) == 0:
+        return
+
     graph = _build_graph(hashable_corpus)
     _set_graph_edge_weights(graph)
     _remove_unreachable_nodes(graph)
@@ -184,6 +189,10 @@ def summarize(text, ratio=0.2, word_count=None, split=False):
     # Warns if the text is too short.
     if len(sentences) < INPUT_MIN_LENGTH:
         logger.warning("Input text is expected to have at least " + str(INPUT_MIN_LENGTH) + " sentences.")
+
+    # If no sentence could be identified, the function ends.
+    if len(sentences) == 0:
+        return
 
     corpus = _build_corpus(sentences)
 

--- a/gensim/test/test_summarization.py
+++ b/gensim/test/test_summarization.py
@@ -85,7 +85,7 @@ class TestSummarizationTest(unittest.TestCase):
         # Keeps the first 8 sentences to make the text shorter.
         text = "\n".join(text.split('\n')[:8])
 
-        self.assertIsNotNone(summarize(text))
+        self.assertTrue(summarize(text) is not None)
 
     def test_corpus_summarization_raises_exception_on_short_input_text(self):
         pre_path = os.path.join(os.path.dirname(__file__), 'test_data')
@@ -101,13 +101,13 @@ class TestSummarizationTest(unittest.TestCase):
         dictionary = Dictionary(tokens)
         corpus = [dictionary.doc2bow(sentence_tokens) for sentence_tokens in tokens]
 
-        self.assertIsNotNone(summarize_corpus(corpus))
+        self.assertTrue(summarize_corpus(corpus) is not None)
 
     def test_empty_text_summarization_none(self):
-        self.assertIsNone(summarize(""))
+        self.assertTrue(summarize("") is None)
 
     def test_empty_corpus_summarization_is_none(self):
-        self.assertIsNone(summarize_corpus([]))
+        self.assertTrue(summarize_corpus([]) is None)
 
     def test_corpus_summarization_ratio(self):
         pre_path = os.path.join(os.path.dirname(__file__), 'test_data')

--- a/gensim/test/test_summarization.py
+++ b/gensim/test/test_summarization.py
@@ -85,7 +85,7 @@ class TestSummarizationTest(unittest.TestCase):
         # Keeps the first 8 sentences to make the text shorter.
         text = "\n".join(text.split('\n')[:8])
 
-        self.assertRaises(RuntimeError, summarize, text)
+        self.assertIsNotNone(summarize(text))
 
     def test_corpus_summarization_raises_exception_on_short_input_text(self):
         pre_path = os.path.join(os.path.dirname(__file__), 'test_data')
@@ -101,7 +101,7 @@ class TestSummarizationTest(unittest.TestCase):
         dictionary = Dictionary(tokens)
         corpus = [dictionary.doc2bow(sentence_tokens) for sentence_tokens in tokens]
 
-        self.assertRaises(RuntimeError, summarize_corpus, corpus)
+        self.assertIsNotNone(summarize_corpus(corpus))
 
     def test_corpus_summarization_ratio(self):
         pre_path = os.path.join(os.path.dirname(__file__), 'test_data')

--- a/gensim/test/test_summarization.py
+++ b/gensim/test/test_summarization.py
@@ -35,7 +35,7 @@ class TestSummarizationTest(unittest.TestCase):
         with utils.smart_open(os.path.join(pre_path, "mihalcea_tarau.summ.txt"), mode="r") as f:
             summary = f.read()
 
-        self.assertEquals(generated_summary, summary)
+        self.assertEqual(generated_summary, summary)
 
     def test_corpus_summarization(self):
         pre_path = os.path.join(os.path.dirname(__file__), 'test_data')

--- a/gensim/test/test_summarization.py
+++ b/gensim/test/test_summarization.py
@@ -103,6 +103,12 @@ class TestSummarizationTest(unittest.TestCase):
 
         self.assertIsNotNone(summarize_corpus(corpus))
 
+    def test_empty_text_summarization_none(self):
+        self.assertIsNone(summarize(""))
+
+    def test_empty_corpus_summarization_is_none(self):
+        self.assertIsNone(summarize_corpus([]))
+
     def test_corpus_summarization_ratio(self):
         pre_path = os.path.join(os.path.dirname(__file__), 'test_data')
 


### PR DESCRIPTION
This fix allows summarizing documents with less than ten sentences, logging a warning in that case.