### PR TITLE
Pure-py train_sentence_sg fix (etc)

### DIFF
--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -319,7 +319,19 @@ class DocvecsArray(utils.SaveLoad):
             return i_index
 
     def __getitem__(self, index):
-        return self.doctag_syn0[self._int_index(index)]
+        """
+        Accept a single key (int or string tag) or list of keys as input.
+
+        If a single string or int, return designated tag's vector
+        representation, as a 1D numpy array.
+
+        If a list, return designated tags' vector representations as a
+        2D numpy array: #tags x #vector_size.
+        """
+        if isinstance(index, string_types + (int,)):
+            return self.doctag_syn0[self._int_index(index)]
+
+        return vstack([self[i] for i in index])
 
     def __len__(self):
         return self.count

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -111,15 +111,15 @@ except ImportError:
         """
         word_vocabs = [model.vocab[w] for w in sentence if w in model.vocab and
                        model.vocab[w].sample_int > model.random.rand() * 2**32]
-        for pos, word in enumerate(sentence):
+        for pos, word in enumerate(word_vocabs):
             reduced_window = model.random.randint(model.window)  # `b` in the original word2vec code
 
             # now go over all words from the (reduced) window, predicting each one in turn
             start = max(0, pos - model.window + reduced_window)
-            for pos2, word2_vocab in enumerate(word_vocabs[start:(pos + model.window + 1 - reduced_window)], start):
+            for pos2, word2 in enumerate(word_vocabs[start:(pos + model.window + 1 - reduced_window)], start):
                 # don't train on the `word` itself
                 if pos2 != pos:
-                    train_sg_pair(model, word, word2_vocab.index, alpha)
+                    train_sg_pair(model, model.index2word[word.index], word2.index, alpha)
 
         return len(word_vocabs)
 

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -715,7 +715,7 @@ class Word2Vec(utils.SaveLoad):
                     job_queue.put((None, 0))  # give the workers heads up that they can finish -- no more work!
                 push_done = True
             try:
-                while done_jobs < (job_no+1):
+                while done_jobs < (job_no+1) or not push_done:
                     word_count += progress_queue.get(push_done)  # only block after all jobs pushed
                     done_jobs += 1
                     elapsed = default_timer() - start


### PR DESCRIPTION
Fix loop-index mismatch causing corrupted training in the pure-python skip-gram path. (Now, all tests pass with equal tolerances both with and without cython-extensions.) 

Also: fix an issue with the 0-worker mode and match Word2Vec.__getitem__'s new ability to take a list of keys on DocvecsArray, too.