### PR TITLE
Modify install problem on gensim/summarization/keywords.py

### DIFF
--- a/gensim/summarization/keywords.py
+++ b/gensim/summarization/keywords.py
@@ -9,7 +9,7 @@ from gensim.summarization.textcleaner import tokenize_by_word as _tokenize_by_wo
 from gensim.summarization.commons import build_graph as _build_graph
 from gensim.summarization.commons import remove_unreachable_nodes as _remove_unreachable_nodes
 from itertools import combinations as _combinations
-from six.moves.queue import Queue as _Queue
+from six.moves import queue
 from six.moves import xrange
 
 
@@ -61,11 +61,11 @@ def _process_first_window(graph, tokens, split_text):
 
 
 def _init_queue(split_text):
-    queue = _Queue()
+    q = queue.Queue()
     first_window = _get_first_window(split_text)
     for word in first_window[1:]:
-        queue.put(word)
-    return queue
+        q.put(word)
+    return q
 
 
 def _process_word(graph, tokens, queue, word):


### PR DESCRIPTION
On my mac(Mac OS X Yosemite, python 2.7.6), there is a install problem.

In 12th line (from six.moves.queue import Queue as _Queue), it incurs import problem.

But I change this line and '_init_queue' function. And then, I can install this library.

I glad to use this library for my research. Thanks.