### PR TITLE
Added --lda parameter for testing

### DIFF
--- a/gensim/models/wrappers/ldavowpalwabbit.py
+++ b/gensim/models/wrappers/ldavowpalwabbit.py
@@ -327,6 +327,7 @@ class LdaVowpalWabbit(utils.SaveLoad):
         """Get list of command line arguments for running prediction."""
         cmd = [self.vw_path,
                '--testonly', # don't update model with this data
+               '--lda', str(self.num_topics),
                '--lda_D', str(corpus_size),
                '-i', self._model_filename, # load existing binary model
                '-d', self._corpus_filename,


### PR DESCRIPTION
This micro patch fixes a segmentation fault when VW is running in test only mode (tested on 7.7.0 and 8.0.0). This bug occurs on OS X (10.10.3). I can give you more details if needed.