### PR TITLE
Modification pull request #408

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -158,7 +158,7 @@ setup(
     install_requires=[
         'numpy >= 1.3',
         'scipy >= 0.7.0',
-        'six >= 1.2.0',
+        'six >= 1.5.0',
         'smart_open >= 1.2.1',
     ],
 


### PR DESCRIPTION
I requested on #408 

But it is pretty weird as you said, so I found what is the problem.

The version of six library is 1.2 and 1.3, problem occurs like in the image.
![image](https://cloud.githubusercontent.com/assets/3727290/8999295/14cdbe00-3773-11e5-8376-8083b3fce6a7.png)

And, the version is 1.4 ...
![image](https://cloud.githubusercontent.com/assets/3727290/8999309/5d750082-3773-11e5-9202-09a01252d36e.png)

Import problems from six library likes above. 

And version is equal or greater than 1.5, there is no problem.

But, The requirement asks me that the version of six is greater than 1.2 in setup.py. 

So, already the six library(version < 1.5) is installed,  it occurs import problem.

I hope it will be helped to solve this problem.