### PR TITLE
Added support for np.ndarrays for SlicedCorpus

### DIFF
--- a/gensim/corpora/indexedcorpus.py
+++ b/gensim/corpora/indexedcorpus.py
@@ -20,7 +20,7 @@ of each document.
 import logging
 import shelve
 
-import numpy as np
+import numpy
 
 from gensim import interfaces, utils
 
@@ -48,6 +48,11 @@ class IndexedCorpus(interfaces.CorpusABC):
             if index_fname is None:
                 index_fname = utils.smart_extension(fname, '.index')
             self.index = utils.unpickle(index_fname)
+            # change self.index into a numpy.ndarray
+            # this will break code like
+            #     if corpus.index:
+            #         do stuff
+            self.index = numpy.asarray(self.index)
             logger.info("loaded corpus index from %s" % index_fname)
         except:
             self.index = None
@@ -96,6 +101,10 @@ class IndexedCorpus(interfaces.CorpusABC):
                 serializer.__name__)
 
         # store offsets persistently, using pickle
+        # we shouldn't have to worry about self.index being a numpy.ndarray as the serializer will return
+        # the offsets that are actually stored on disk - we're not storing self.index in any case, the
+        # load just needs to turn whatever is loaded from disk back into a ndarray - this should also be
+        # backwards compatible
         logger.info("saving %s index to %s" % (serializer.__name__, index_fname))
         utils.pickle(offsets, index_fname)
 
@@ -115,7 +124,7 @@ class IndexedCorpus(interfaces.CorpusABC):
         if self.index is None:
             raise RuntimeError("cannot call corpus[docid] without an index")
 
-        if isinstance(docno, slice) or isinstance(docno, np.ndarray):
+        if isinstance(docno, (slice, numpy.ndarray)):
             return utils.SlicedCorpus(self, docno)
 
         return self.docbyoffset(self.index[docno])

--- a/gensim/corpora/indexedcorpus.py
+++ b/gensim/corpora/indexedcorpus.py
@@ -124,10 +124,12 @@ class IndexedCorpus(interfaces.CorpusABC):
         if self.index is None:
             raise RuntimeError("cannot call corpus[docid] without an index")
 
-        if isinstance(docno, (slice, numpy.ndarray)):
+        if isinstance(docno, (slice, list, numpy.ndarray)):
             return utils.SlicedCorpus(self, docno)
-
-        return self.docbyoffset(self.index[docno])
+        elif isinstance(docno, (int, numpy.int)):
+            return self.docbyoffset(self.index[docno])
+        else:
+            raise ValueError('Unrecognised value for docno, use either a single integer, a slice or a numpy.ndarray')
 
 
 

--- a/gensim/corpora/indexedcorpus.py
+++ b/gensim/corpora/indexedcorpus.py
@@ -123,7 +123,7 @@ class IndexedCorpus(interfaces.CorpusABC):
 
         if isinstance(docno, (slice, list, numpy.ndarray)):
             return utils.SlicedCorpus(self, docno)
-        elif isinstance(docno, (int, numpy.int)):
+        elif isinstance(docno, (int, numpy.integer)):
             return self.docbyoffset(self.index[docno])
         else:
             raise ValueError('Unrecognised value for docno, use either a single integer, a slice or a numpy.ndarray')

--- a/gensim/corpora/indexedcorpus.py
+++ b/gensim/corpora/indexedcorpus.py
@@ -48,10 +48,7 @@ class IndexedCorpus(interfaces.CorpusABC):
             if index_fname is None:
                 index_fname = utils.smart_extension(fname, '.index')
             self.index = utils.unpickle(index_fname)
-            # change self.index into a numpy.ndarray
-            # this will break code like
-            #     if corpus.index:
-            #         do stuff
+            # change self.index into a numpy.ndarray to support fancy indexing
             self.index = numpy.asarray(self.index)
             logger.info("loaded corpus index from %s" % index_fname)
         except:
@@ -103,8 +100,8 @@ class IndexedCorpus(interfaces.CorpusABC):
         # store offsets persistently, using pickle
         # we shouldn't have to worry about self.index being a numpy.ndarray as the serializer will return
         # the offsets that are actually stored on disk - we're not storing self.index in any case, the
-        # load just needs to turn whatever is loaded from disk back into a ndarray - this should also be
-        # backwards compatible
+        # load just needs to turn whatever is loaded from disk back into a ndarray - this should also ensure
+        # backwards compatibility
         logger.info("saving %s index to %s" % (serializer.__name__, index_fname))
         utils.pickle(offsets, index_fname)
 

--- a/gensim/corpora/indexedcorpus.py
+++ b/gensim/corpora/indexedcorpus.py
@@ -20,6 +20,8 @@ of each document.
 import logging
 import shelve
 
+import numpy as np
+
 from gensim import interfaces, utils
 
 logger = logging.getLogger('gensim.corpora.indexedcorpus')
@@ -113,7 +115,7 @@ class IndexedCorpus(interfaces.CorpusABC):
         if self.index is None:
             raise RuntimeError("cannot call corpus[docid] without an index")
 
-        if isinstance(docno, slice):
+        if isinstance(docno, slice) or isinstance(docno, np.ndarray):
             return utils.SlicedCorpus(self, docno)
 
         return self.docbyoffset(self.index[docno])

--- a/gensim/test/test_corpora.py
+++ b/gensim/test/test_corpora.py
@@ -14,6 +14,8 @@ import unittest
 import tempfile
 import itertools
 
+import numpy
+
 from gensim.utils import to_unicode, smart_extension
 from gensim.corpora import (bleicorpus, mmcorpus, lowcorpus, svmlightcorpus,
                             ucicorpus, malletcorpus, textcorpus, indexedcorpus)
@@ -105,6 +107,12 @@ class CorpusTestCase(unittest.TestCase):
         for i in range(len(corpus)):
             self.assertEqual(corpus[i], corpus2[i])
 
+        # make sure that subclasses of IndexedCorpus support fancy indexing
+        # after deserialisation
+        if isinstance(corpus, indexedcorpus.IndexedCorpus):
+            idx = [1, 3, 5, 7]
+            self.assertEquals(corpus[idx], corpus2[idx])
+
     def test_serialize_compressed(self):
         corpus = self.TEST_CORPUS
 
@@ -160,6 +168,21 @@ class CorpusTestCase(unittest.TestCase):
         self.assertEqual(len(docs), len(corpus))
         self.assertEqual(len(docs), len(corpus[:]))
         self.assertEqual(len(docs[::2]), len(corpus[::2]))
+        
+        # make sure proper input validation for sliced corpora is done
+        with self.assertRaises(ValueError):
+            corpus[set([1])]
+            
+        with self.assertRaises(ValueError):
+            corpus[1.0]
+
+        # check sliced corpora that use fancy indexing
+        c = corpus[[1, 3, 4]]
+        self.assertEquals([d for i, d in enumerate(docs) if i in [1, 3, 4]], list(c))
+        self.assertEquals([d for i, d in enumerate(docs) if i in [1, 3, 4]], list(c))
+        self.assertEquals(len(corpus[[0, 1, -1]]), 3)
+        self.assertEquals(len(corpus[numpy.asarray([0, 1, -1])]), 3)
+
 
 class TestMmCorpus(CorpusTestCase):
     def setUp(self):

--- a/gensim/test/test_corpora.py
+++ b/gensim/test/test_corpora.py
@@ -169,12 +169,13 @@ class CorpusTestCase(unittest.TestCase):
         self.assertEqual(len(docs), len(corpus[:]))
         self.assertEqual(len(docs[::2]), len(corpus[::2]))
         
+        def _get_slice(corpus, slice_):
+            # assertRaises for python 2.6 takes a callable
+            return corpus[slice_]
+
         # make sure proper input validation for sliced corpora is done
-        with self.assertRaises(ValueError):
-            corpus[set([1])]
-            
-        with self.assertRaises(ValueError):
-            corpus[1.0]
+        self.assertRaises(ValueError, _get_slice, corpus, set([1]))
+        self.assertRaises(ValueError, _get_slice, corpus, 1.0)
 
         # check sliced corpora that use fancy indexing
         c = corpus[[1, 3, 4]]

--- a/gensim/utils.py
+++ b/gensim/utils.py
@@ -705,7 +705,7 @@ class SlicedCorpus(SaveLoad):
         self.length = None
 
     def __iter__(self):
-        if hasattr(self.corpus, 'index') and self.corpus.index:
+        if hasattr(self.corpus, 'index') and len(self.corpus.index) > 0:
             return (self.corpus.docbyoffset(i) for i in
                     self.corpus.index[self.slice_])
         else:

--- a/gensim/utils.py
+++ b/gensim/utils.py
@@ -699,6 +699,7 @@ class SlicedCorpus(SaveLoad):
         Negative slicing can only be used if the corpus is indexable.
         Otherwise, the corpus will be iterated over.
 
+        Slice can also be a numpy.ndarray to support fancy indexing.
         """
         self.corpus = corpus
         self.slice_ = slice_

--- a/gensim/utils.py
+++ b/gensim/utils.py
@@ -700,6 +700,11 @@ class SlicedCorpus(SaveLoad):
         Otherwise, the corpus will be iterated over.
 
         Slice can also be a numpy.ndarray to support fancy indexing.
+
+        NOTE: calculating the size of a SlicedCorpus is expensive
+        when using a slice as the corpus has to be iterated over once.
+        Using a list or numpy.ndarray does not have this drawback, but
+        consumes more memory.
         """
         self.corpus = corpus
         self.slice_ = slice_
@@ -716,7 +721,10 @@ class SlicedCorpus(SaveLoad):
     def __len__(self):
         # check cached length, calculate if needed
         if self.length is None:
-            self.length = sum(1 for x in self)
+            if isinstance(self.slice_, (list, numpy.ndarray)):
+                self.length = len(self.slice_)
+            else:
+                self.length = sum(1 for x in self)
 
         return self.length
 


### PR DESCRIPTION
The SlicedCorpus currently only supports slicing using Python lists. It would be quite useful if the slicing could be done similar to NumPy fancy indexing. I think the changes needed are quite simple.

Not sure how to handle the serialisation of the `index` though (turn it into a list - seems silly).