### PR TITLE
Add exception handling when importing from different versions of scipy

### DIFF
--- a/gensim/models/doc2vec_inner.pyx
+++ b/gensim/models/doc2vec_inner.pyx
@@ -15,7 +15,12 @@ cimport numpy as np
 from libc.math cimport exp
 from libc.string cimport memset, memcpy
 
-from scipy.linalg.blas import fblas
+# scipy <= 0.15
+try:
+     from scipy.linalg.blas import fblas
+except ImportError:
+     # in scipy > 0.15, fblas function has been removed
+     import scipy.linalg.blas as fblas
 
 from word2vec_inner cimport bisect_left, random_int32, \
      scopy, saxpy, sdot, dsdot, snrm2, sscal, \

--- a/gensim/models/word2vec_inner.pyx
+++ b/gensim/models/word2vec_inner.pyx
@@ -15,7 +15,12 @@ from libc.math cimport exp
 from libc.math cimport log
 from libc.string cimport memset
 
-from scipy.linalg.blas import fblas
+# scipy <= 0.15
+try:
+    from scipy.linalg.blas import fblas
+except ImportError:
+    # in scipy > 0.15, fblas function has been removed
+    import scipy.linalg.blas as fblas
 
 REAL = np.float32
 


### PR DESCRIPTION
As per #382, add some exception handling when importing scipy linalg module.