### PR TITLE
Fixed compatibility with S3 for gensim.utils.SaveLoad

### DIFF
--- a/gensim/utils.py
+++ b/gensim/utils.py
@@ -915,7 +915,7 @@ def pickle(obj, fname, protocol=2):
 def unpickle(fname):
     """Load pickled object from `fname`"""
     with smart_open(fname) as f:
-        return _pickle.load(f)
+        return _pickle.loads(f.read())
 
 
 def revdict(d):

--- a/gensim/utils.py
+++ b/gensim/utils.py
@@ -915,6 +915,7 @@ def pickle(obj, fname, protocol=2):
 def unpickle(fname):
     """Load pickled object from `fname`"""
     with smart_open(fname) as f:
+        # Because of loading from S3 load can't be used (missing readline in smart_open)
         return _pickle.loads(f.read())
 
 


### PR DESCRIPTION
Minor fix that enables loading objects that inherited from `gensim.utils.SaveLoad` also from Amazon S3. Bug was described in https://github.com/piskvorky/gensim/issues/421.

This implementation is necessary, before there will be fixed issues https://github.com/piskvorky/smart_open/issues/13 and https://github.com/piskvorky/smart_open/issues/27 in smart_open library.