### PR TITLE
TransformedCorpus should still be `slice`able.

### DIFF
--- a/gensim/interfaces.py
+++ b/gensim/interfaces.py
@@ -120,6 +120,12 @@ class TransformedCorpus(CorpusABC):
         else:
             for doc in self.corpus:
                 yield self.obj[doc]
+
+    def __getitem__(self, docno):
+        if hasattr(self.corpus, '__getitem__'):
+           return self.corpus[docno]
+        else:
+            raise RuntimeError('Type {} does not support slicing.'.format(type(self.corpus)))
 #endclass TransformedCorpus
 
 

--- a/gensim/test/test_corpora.py
+++ b/gensim/test/test_corpora.py
@@ -17,6 +17,7 @@ import itertools
 import numpy
 
 from gensim.utils import to_unicode, smart_extension
+from gensim.interfaces import TransformedCorpus
 from gensim.corpora import (bleicorpus, mmcorpus, lowcorpus, svmlightcorpus,
                             ucicorpus, malletcorpus, textcorpus, indexedcorpus)
 
@@ -183,6 +184,18 @@ class CorpusTestCase(unittest.TestCase):
         self.assertEquals([d for i, d in enumerate(docs) if i in [1, 3, 4]], list(c))
         self.assertEquals(len(corpus[[0, 1, -1]]), 3)
         self.assertEquals(len(corpus[numpy.asarray([0, 1, -1])]), 3)
+
+        # check that TransformedCorpus supports indexing when the underlying
+        # corpus does, and throws an error otherwise
+        if hasattr(corpus, 'index'):
+            corpus_ = TransformedCorpus(None, corpus)
+            self.assertEqual(corpus_[0], docs[0])
+            self.assertRaises(ValueError, _get_slice, corpus_, set([1]))
+            self.assertEquals([d for i, d in enumerate(docs) if i in [1, 3, 4]], list(corpus_[[1, 3, 4]]))
+        else:
+            self.assertRaises(RuntimeError, _get_slice, corpus_, [1, 3, 4])
+            self.assertRaises(RuntimeError, _get_slice, corpus_, set([1]))
+            self.assertRaises(RuntimeError, _get_slice, corpus_, 1.0)
 
 
 class TestMmCorpus(CorpusTestCase):


### PR DESCRIPTION
Added support for slicing a `TransformedCorpus`. For instance, the corpus returned from applying `TfIdfModel` can still be randomly indexed, not just iterated over.