### PR TITLE
TransformedCorpus should still be `slice`able.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,12 +1,10 @@
 Changes
 =======
 
-0.12.3
-
-* added support for sliced TransformedCorpus objects, so that after applying (for instance) TfidfModel the returned corpus remains randomly indexable. (Matti Lyra, #425)
 
 0.12.2
 
+* added support for sliced TransformedCorpus objects, so that after applying (for instance) TfidfModel the returned corpus remains randomly indexable. (Matti Lyra, #425)
 * added support for NumPy style fancy indexing to corpus objects (Matti Lyra, #414)
 
 0.12.1, 20/07/2015

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,10 @@
 Changes
 =======
 
+0.12.3
+
+* added support for sliced TransformedCorpus objects, so that after applying (for instance) TfidfModel the returned corpus remains randomly indexable. (Matti Lyra, #425)
+
 0.12.2
 
 * added support for NumPy style fancy indexing to corpus objects (Matti Lyra, #414)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ Changes
 0.12.2
 
 * added support for sliced TransformedCorpus objects, so that after applying (for instance) TfidfModel the returned corpus remains randomly indexable. (Matti Lyra, #425)
+* changed the LdaModel.save so that a custom `ignore` list can be passed in (Matti Lyra, #331)
 * added support for NumPy style fancy indexing to corpus objects (Matti Lyra, #414)
 
 0.12.1, 20/07/2015

--- a/gensim/interfaces.py
+++ b/gensim/interfaces.py
@@ -123,7 +123,7 @@ class TransformedCorpus(CorpusABC):
 
     def __getitem__(self, docno):
         if hasattr(self.corpus, '__getitem__'):
-           return self.corpus[docno]
+           return self.obj[self.corpus[docno]]
         else:
             raise RuntimeError('Type {} does not support slicing.'.format(type(self.corpus)))
 #endclass TransformedCorpus

--- a/gensim/test/test_corpora.py
+++ b/gensim/test/test_corpora.py
@@ -31,6 +31,17 @@ def testfile():
     return os.path.join(tempfile.gettempdir(), 'gensim_corpus.tst')
 
 
+class DummyTransformer(object):
+    def __getitem__(self, bow):
+        if len(next(iter(bow))) == 2:
+            # single bag of words
+            transformed = [(termid, count + 1) for termid, count in bow]
+        else:
+            # sliced corpus
+            transformed = [[(termid, count + 1) for termid, count in doc] for doc in bow]
+        return transformed
+
+
 class CorpusTestCase(unittest.TestCase):
     TEST_CORPUS = [[(1, 1.0)], [], [(0, 0.5), (2, 1.0)], []]
 
@@ -188,10 +199,11 @@ class CorpusTestCase(unittest.TestCase):
         # check that TransformedCorpus supports indexing when the underlying
         # corpus does, and throws an error otherwise
         if hasattr(corpus, 'index'):
-            corpus_ = TransformedCorpus(None, corpus)
-            self.assertEqual(corpus_[0], docs[0])
+            corpus_ = TransformedCorpus(DummyTransformer(), corpus)
+            self.assertEqual(corpus_[0][0][1], docs[0][0][1]+1)
             self.assertRaises(ValueError, _get_slice, corpus_, set([1]))
-            self.assertEquals([d for i, d in enumerate(docs) if i in [1, 3, 4]], list(corpus_[[1, 3, 4]]))
+            transformed_docs = [val+1 for i, d in enumerate(docs) for _, val in d if i in [1, 3, 4]]
+            self.assertEquals(transformed_docs, list(v for doc in corpus_[[1, 3, 4]] for _, v in doc))
         else:
             self.assertRaises(RuntimeError, _get_slice, corpus_, [1, 3, 4])
             self.assertRaises(RuntimeError, _get_slice, corpus_, set([1]))

--- a/gensim/test/test_corpora.py
+++ b/gensim/test/test_corpora.py
@@ -204,6 +204,7 @@ class CorpusTestCase(unittest.TestCase):
             self.assertRaises(ValueError, _get_slice, corpus_, set([1]))
             transformed_docs = [val+1 for i, d in enumerate(docs) for _, val in d if i in [1, 3, 4]]
             self.assertEquals(transformed_docs, list(v for doc in corpus_[[1, 3, 4]] for _, v in doc))
+            self.assertEqual(3, len(corpus_[[1, 3, 4]]))
         else:
             self.assertRaises(RuntimeError, _get_slice, corpus_, [1, 3, 4])
             self.assertRaises(RuntimeError, _get_slice, corpus_, set([1]))

--- a/gensim/test/test_corpora.py
+++ b/gensim/test/test_corpora.py
@@ -198,7 +198,7 @@ class CorpusTestCase(unittest.TestCase):
 
         # check that TransformedCorpus supports indexing when the underlying
         # corpus does, and throws an error otherwise
-        if hasattr(corpus, 'index'):
+        if hasattr(corpus, 'index') and corpus.index is not None:
             corpus_ = TransformedCorpus(DummyTransformer(), corpus)
             self.assertEqual(corpus_[0][0][1], docs[0][0][1]+1)
             self.assertRaises(ValueError, _get_slice, corpus_, set([1]))


### PR DESCRIPTION
Fixes a bug in PR #424 where the transformation was not being applied to a sliced TransformedCorpus. Added test case, and an entry in the CHANGELOG.