### PR TITLE
Fix dispatching in Python3

### DIFF
--- a/gensim/models/lsi_dispatcher.py
+++ b/gensim/models/lsi_dispatcher.py
@@ -122,7 +122,7 @@ class Dispatcher(object):
         # but merging only takes place once, after all input data has been processed,
         # so the overall effect would be small... compared to the amount of coding :-)
         logger.info("merging states from %i workers" % len(self.workers))
-        workers = self.workers.items()
+        workers = list(self.workers.items())
         result = workers[0][1].getstate()
         for workerid, worker in workers[1:]:
             logger.info("pulling state from worker %s" % workerid)


### PR DESCRIPTION
Following the instructions on setting up a distributed LSI, I ran into 

    TypeError: 'dict_items' object does not support indexing

This one-liner seemed to do the trick. I would have added a unit-test as well but there doesn't
seem to be any for distributated computing.