### PR TITLE
Adds an optional vocab trimming rule parameter to word2vec

### DIFF
--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -499,7 +499,7 @@ class Doc2Vec(Word2Vec):
     def __init__(self, documents=None, size=300, alpha=0.025, window=8, min_count=5,
                  max_vocab_size=None, sample=0, seed=1, workers=1, min_alpha=0.0001,
                  dm=1, hs=1, negative=0, dbow_words=0, dm_mean=0, dm_concat=0, dm_tag_count=1,
-                 docvecs=None, docvecs_mapfile=None, comment=None, **kwargs):
+                 docvecs=None, docvecs_mapfile=None, comment=None, trim_rule=None, **kwargs):
         """
         Initialize the model from an iterable of `documents`. Each document is a
         TaggedDocument object that will be used for training.
@@ -569,7 +569,7 @@ class Doc2Vec(Word2Vec):
         self.docvecs = docvecs or DocvecsArray(docvecs_mapfile)
         self.comment = comment
         if documents is not None:
-            self.build_vocab(documents)
+            self.build_vocab(documents, trim_rule=trim_rule)
             self.train(documents)
 
     @property
@@ -597,7 +597,7 @@ class Doc2Vec(Word2Vec):
         self.docvecs.borrow_from(other_model.docvecs)
         super(Doc2Vec, self).reset_from(other_model)
 
-    def scan_vocab(self, documents, progress_per=10000):
+    def scan_vocab(self, documents, progress_per=10000, trim_rule=None):
         logger.info("collecting all words and their counts")
         document_no = -1
         total_words = 0
@@ -622,7 +622,7 @@ class Doc2Vec(Word2Vec):
             total_words += len(document.words)
 
             if self.max_vocab_size and len(vocab) > self.max_vocab_size:
-                utils.prune_vocab(vocab, min_reduce)
+                utils.prune_vocab(vocab, min_reduce, trim_rule=trim_rule)
                 min_reduce += 1
 
         logger.info("collected %i word types and %i unique tags from a corpus of %i examples and %i words",

--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -553,6 +553,13 @@ class Doc2Vec(Word2Vec):
         `dbow_words` if set to 1 trains word-vectors (in skip-gram fashion) simultaneous with DBOW
         doc-vector training; default is 0 (faster training of doc-vectors only).
 
+        `trim_rule` = vocabulary trimming rule, specifies whether certain words should remain
+         in the vocabulary, be trimmed away, or handled using the default (discard if word count < min_count).
+         Can be None (min_count will be used), or a callable that accepts parameters (word, count, min_count) and
+         returns either word2vec.RULE_DISCARD, word2vec.RULE_KEEP or word2vec.RULE_DEFAULT.
+         Note: The rule, if given, is only used prune vocabulary during build_vocab() and is not stored as part
+          of the model.
+
         """
         super(Doc2Vec, self).__init__(
             size=size, alpha=alpha, window=window, min_count=min_count, max_vocab_size=max_vocab_size,

--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -556,7 +556,7 @@ class Doc2Vec(Word2Vec):
         `trim_rule` = vocabulary trimming rule, specifies whether certain words should remain
          in the vocabulary, be trimmed away, or handled using the default (discard if word count < min_count).
          Can be None (min_count will be used), or a callable that accepts parameters (word, count, min_count) and
-         returns either word2vec.RULE_DISCARD, word2vec.RULE_KEEP or word2vec.RULE_DEFAULT.
+         returns either util.RULE_DISCARD, util.RULE_KEEP or util.RULE_DEFAULT.
          Note: The rule, if given, is only used prune vocabulary during build_vocab() and is not stored as part
           of the model.
 

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -77,7 +77,7 @@ from copy import deepcopy
 from collections import defaultdict
 import threading
 
-from gensim.utils import _keep_vocab_item
+from gensim.utils import keep_vocab_item
 
 try:
     from queue import Queue, Empty
@@ -393,7 +393,7 @@ class Word2Vec(utils.SaveLoad):
         `trim_rule` = vocabulary trimming rule, specifies whether certain words should remain
          in the vocabulary, be trimmed away, or handled using the default (discard if word count < min_count).
          Can be None (min_count will be used), or a callable that accepts parameters (word, count, min_count) and
-         returns either word2vec.RULE_DISCARD, word2vec.RULE_KEEP or word2vec.RULE_DEFAULT.
+         returns either util.RULE_DISCARD, util.RULE_KEEP or util.RULE_DEFAULT.
          Note: The rule, if given, is only used prune vocabulary during build_vocab() and is not stored as part
           of the model.
 
@@ -546,7 +546,7 @@ class Word2Vec(utils.SaveLoad):
         drop_unique, drop_total, retain_total, original_total = 0, 0, 0, 0
         retain_words = []
         for word, v in iteritems(self.raw_vocab):
-            if _keep_vocab_item(word, v, min_count, trim_rule=trim_rule):
+            if keep_vocab_item(word, v, min_count, trim_rule=trim_rule):
                 retain_words.append(word)
                 retain_total += v
                 original_total += v

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -514,7 +514,7 @@ class Word2Vec(utils.SaveLoad):
         sentence_no = -1
         total_words = 0
         min_reduce = 1
-        _modified_trim_rule = lambda (word, count, min_count): keep_vocab_item(word, count, min_count, self.trim_rule)
+        _modified_trim_rule = lambda word, count, min_count: keep_vocab_item(word, count, min_count, self.trim_rule)
         vocab = defaultdict(int)
         for sentence_no, sentence in enumerate(sentences):
             if sentence_no % progress_per == 0:

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -328,7 +328,7 @@ class Vocab(object):
 
 
 def keep_vocab_item(word, count, min_count):
-    return count >= min_count
+    pass
 
 
 class Word2Vec(utils.SaveLoad):
@@ -435,6 +435,9 @@ class Word2Vec(utils.SaveLoad):
                     return False
                 else:
                     return default_res
+        else:
+            def keep_vocab_item(word, count, min_count):
+                return count >= min_count
 
         self.trim_rule = keep_vocab_item
 

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -420,13 +420,19 @@ class Word2Vec(utils.SaveLoad):
         RULE_KEEP = 2
 
         if trim_rule:
-            def keep_vocab_item(word, count, min_count_):
+            def keep_vocab_item(word, count, min_count):
                 rule_res = trim_rule(word, count, min_count)
-                default_res = count >= min_count_
-                return True if (rule_res == RULE_KEEP) else (False if (rule_res == RULE_DISCARD) else default_res)
+                default_res = count >= min_count
+
+                if rule_res == RULE_KEEP:
+                    return True
+                elif rule_res == RULE_DISCARD:
+                    return False
+                else:
+                    return default_res
         else:
-            def keep_vocab_item(word, count, min_count_):
-                return count >= min_count_
+            def keep_vocab_item(word, count, min_count):
+                return count >= min_count
         self.trim_rule = keep_vocab_item
 
         if sentences is not None:

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -327,6 +327,10 @@ class Vocab(object):
         return "%s(%s)" % (self.__class__.__name__, ', '.join(vals))
 
 
+def keep_vocab_item(word, count, min_count):
+    return count >= min_count
+
+
 class Word2Vec(utils.SaveLoad):
     """
     Class for training, using and evaluating neural networks described in https://code.google.com/p/word2vec/
@@ -419,6 +423,7 @@ class Word2Vec(utils.SaveLoad):
         RULE_DISCARD = 1
         RULE_KEEP = 2
 
+        global keep_vocab_item
         if trim_rule:
             def keep_vocab_item(word, count, min_count):
                 rule_res = trim_rule(word, count, min_count)
@@ -430,9 +435,7 @@ class Word2Vec(utils.SaveLoad):
                     return False
                 else:
                     return default_res
-        else:
-            def keep_vocab_item(word, count, min_count):
-                return count >= min_count
+
         self.trim_rule = keep_vocab_item
 
         if sentences is not None:

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -421,13 +421,13 @@ class Word2Vec(utils.SaveLoad):
 
         if trim_rule:
             def keep_vocab_item(word, count, min_count_):
-                rule_res = self.trim_rule(word, count)
+                rule_res = trim_rule(word, count)
                 default_res = count >= min_count_
                 return True if (rule_res == RULE_KEEP) else (False if (rule_res == RULE_DISCARD) else default_res)
         else:
             def keep_vocab_item(word, count, min_count_):
                 return count >= min_count_
-        self.keep_vocab_item = keep_vocab_item
+        self.trim_rule = keep_vocab_item
 
         if sentences is not None:
             if isinstance(sentences, GeneratorType):
@@ -515,7 +515,7 @@ class Word2Vec(utils.SaveLoad):
                 vocab[word] += 1
 
             if self.max_vocab_size and len(vocab) > self.max_vocab_size:
-                total_words += utils.prune_vocab(vocab, min_reduce, rule=self.keep_vocab_item)
+                total_words += utils.prune_vocab(vocab, min_reduce, trim_rule=self.trim_rule)
                 min_reduce += 1
 
         total_words += sum(itervalues(vocab))
@@ -551,7 +551,7 @@ class Word2Vec(utils.SaveLoad):
         drop_unique, drop_total, retain_total, original_total = 0, 0, 0, 0
         retain_words = []
         for word, v in iteritems(self.raw_vocab):
-            if self.keep_vocab_item(word, v, min_count):
+            if self.trim_rule(word, v, min_count):
                 retain_words.append(word)
                 retain_total += v
                 original_total += v

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -421,7 +421,7 @@ class Word2Vec(utils.SaveLoad):
 
         if trim_rule:
             def keep_vocab_item(word, count, min_count_):
-                rule_res = trim_rule(word, count)
+                rule_res = trim_rule(word, count, min_count)
                 default_res = count >= min_count_
                 return True if (rule_res == RULE_KEEP) else (False if (rule_res == RULE_DISCARD) else default_res)
         else:

--- a/gensim/test/test_word2vec.py
+++ b/gensim/test/test_word2vec.py
@@ -52,9 +52,9 @@ def testfile():
 
 def rule_for_testing(word, count, min_count):
     if word == "human":
-        return word2vec.RULE_DISCARD  # throw out
+        return utils.RULE_DISCARD  # throw out
     else:
-        return word2vec.RULE_DEFAULT  # apply default rule, i.e. min_count
+        return utils.RULE_DEFAULT  # apply default rule, i.e. min_count
 
 class TestWord2VecModel(unittest.TestCase):
     def testPersistence(self):

--- a/gensim/test/test_word2vec.py
+++ b/gensim/test/test_word2vec.py
@@ -70,17 +70,22 @@ class TestWord2VecModel(unittest.TestCase):
         self.models_equal(model, word2vec.Word2Vec.load(testfile()))
 
     def testRuleWithMinCount(self):
-        """Test that returning RULE_DEFAULT from trim_rule triggers min_count"""
+        """Test that returning RULE_DEFAULT from trim_rule triggers min_count."""
         model = word2vec.Word2Vec(sentences + [["occurs_only_once"]], min_count=2, trim_rule=rule_for_testing)
         self.assertTrue("human" not in model.vocab)
         self.assertTrue("occurs_only_once" not in model.vocab)
         self.assertTrue("interface" in model.vocab)
 
-
     def testRule(self):
-        """Test applying vocab trim_rule to build_vocab instead of constructor"""
+        """Test applying vocab trim_rule to build_vocab instead of constructor."""
         model = word2vec.Word2Vec(min_count=1)
         model.build_vocab(sentences, trim_rule=rule_for_testing)
+        self.assertTrue("human" not in model.vocab)
+
+    def testLambdaRule(self):
+        """Test that lambda trim_rule works."""
+        rule = lambda word, count, min_count: utils.RULE_DISCARD if word == "human" else utils.RULE_DEFAULT
+        model = word2vec.Word2Vec(sentences, min_count=1, trim_rule=rule)
         self.assertTrue("human" not in model.vocab)
 
     def testPersistenceWord2VecFormat(self):

--- a/gensim/test/test_word2vec.py
+++ b/gensim/test/test_word2vec.py
@@ -50,6 +50,11 @@ def testfile():
     # temporary data will be stored to this file
     return os.path.join(tempfile.gettempdir(), 'gensim_word2vec.tst')
 
+def rule_for_testing(word, count, min_count):
+    if word == "human":
+        return 1  # throw out
+    else:
+        return 0  # default rule
 
 class TestWord2VecModel(unittest.TestCase):
     def testPersistence(self):
@@ -57,6 +62,13 @@ class TestWord2VecModel(unittest.TestCase):
         model = word2vec.Word2Vec(sentences, min_count=1)
         model.save(testfile())
         self.models_equal(model, word2vec.Word2Vec.load(testfile()))
+
+    def testPersistenceWithRule(self):
+        """Test storing/loading the entire model with vocab trimming rule."""
+        model = word2vec.Word2Vec(sentences, min_count=1, trim_rule=rule_for_testing)
+        model.save(testfile())
+        self.models_equal(model, word2vec.Word2Vec.load(testfile()))
+        self.assertTrue("human" not in model.vocab)
 
     def testPersistenceWord2VecFormat(self):
         """Test storing/loading the entire model in word2vec format."""

--- a/gensim/utils.py
+++ b/gensim/utils.py
@@ -11,6 +11,7 @@ This module contains various general utility functions.
 from __future__ import with_statement
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 try:
@@ -1096,13 +1097,32 @@ def prune_vocab(vocab, min_reduce, trim_rule=None):
     Modifies `vocab` in place, returns the sum of all counts that were pruned.
 
     """
-    trim_rule = trim_rule or (lambda word, count, min_count: count >= min_reduce)
     result = 0
     old_len = len(vocab)
     for w in list(vocab):  # make a copy of dict's keys
-        if not trim_rule(w, vocab[w], min_reduce):  # vocab[w] <= min_reduce:
+        if not _keep_vocab_item(w, vocab[w], min_reduce, trim_rule):  # vocab[w] <= min_reduce:
             result += vocab[w]
             del vocab[w]
     logger.info("pruned out %i tokens with count <=%i (before %i, after %i)",
                 old_len - len(vocab), min_reduce, old_len, len(vocab))
     return result
+
+
+RULE_DEFAULT = 0
+RULE_DISCARD = 1
+RULE_KEEP = 2
+
+
+def _keep_vocab_item(word, count, min_count, trim_rule=None):
+    default_res = count >= min_count
+
+    if trim_rule is None:
+        return default_res
+    else:
+        rule_res = trim_rule(word, count, min_count)
+        if rule_res == RULE_KEEP:
+            return True
+        elif rule_res == RULE_DISCARD:
+            return False
+        else:
+            return default_res

--- a/gensim/utils.py
+++ b/gensim/utils.py
@@ -1089,17 +1089,18 @@ def mock_data(n_items=1000, dim=1000, prob_nnz=0.5, lam=1.0):
     return data
 
 
-def prune_vocab(vocab, min_reduce):
+def prune_vocab(vocab, min_reduce, keep_rule=None):
     """
     Remove all entries from the `vocab` dictionary with count smaller than `min_reduce`.
 
     Modifies `vocab` in place, returns the sum of all counts that were pruned.
 
     """
+    keep_rule = keep_rule or (lambda word, count, min_count: count >= min_reduce)
     result = 0
     old_len = len(vocab)
     for w in list(vocab):  # make a copy of dict's keys
-        if vocab[w] <= min_reduce:
+        if not keep_rule(w, vocab[w], min_reduce):  # vocab[w] <= min_reduce:
             result += vocab[w]
             del vocab[w]
     logger.info("pruned out %i tokens with count <=%i (before %i, after %i)",

--- a/gensim/utils.py
+++ b/gensim/utils.py
@@ -1089,18 +1089,18 @@ def mock_data(n_items=1000, dim=1000, prob_nnz=0.5, lam=1.0):
     return data
 
 
-def prune_vocab(vocab, min_reduce, keep_rule=None):
+def prune_vocab(vocab, min_reduce, trim_rule=None):
     """
     Remove all entries from the `vocab` dictionary with count smaller than `min_reduce`.
 
     Modifies `vocab` in place, returns the sum of all counts that were pruned.
 
     """
-    keep_rule = keep_rule or (lambda word, count, min_count: count >= min_reduce)
+    trim_rule = trim_rule or (lambda word, count, min_count: count >= min_reduce)
     result = 0
     old_len = len(vocab)
     for w in list(vocab):  # make a copy of dict's keys
-        if not keep_rule(w, vocab[w], min_reduce):  # vocab[w] <= min_reduce:
+        if not trim_rule(w, vocab[w], min_reduce):  # vocab[w] <= min_reduce:
             result += vocab[w]
             del vocab[w]
     logger.info("pruned out %i tokens with count <=%i (before %i, after %i)",

--- a/gensim/utils.py
+++ b/gensim/utils.py
@@ -1100,7 +1100,7 @@ def prune_vocab(vocab, min_reduce, trim_rule=None):
     result = 0
     old_len = len(vocab)
     for w in list(vocab):  # make a copy of dict's keys
-        if not _keep_vocab_item(w, vocab[w], min_reduce, trim_rule):  # vocab[w] <= min_reduce:
+        if not keep_vocab_item(w, vocab[w], min_reduce, trim_rule):  # vocab[w] <= min_reduce:
             result += vocab[w]
             del vocab[w]
     logger.info("pruned out %i tokens with count <=%i (before %i, after %i)",
@@ -1113,7 +1113,7 @@ RULE_DISCARD = 1
 RULE_KEEP = 2
 
 
-def _keep_vocab_item(word, count, min_count, trim_rule=None):
+def keep_vocab_item(word, count, min_count, trim_rule=None):
     default_res = count >= min_count
 
     if trim_rule is None:


### PR DESCRIPTION
This addresses #423, basically implementing the per-word three-return-value option @gojomo described. I've tested this locally and it seems to be working fine, but I think the test for saving a model was still failing. Opening this PR now so I can get some input on it from you guys.

Example usage (wiki2vec for dbpedia spotlight):
```python
def read_corpus(path_to_corpus, output_path, min_count=10, size=500, window=10, entity_min_count=5):
    sentences = gensim.models.word2vec.LineSentence(path_to_corpus)

    def rule(word, count, min_count):
        if word.startswith("DBPEDIA_ID/") and count >= entity_min_count:
            return 2 # Keep this word
        else:
            return 0 # Don't care. Do whatever the default is (i.e. min_count is applied later)

    model = gensim.models.Word2Vec(None, min_count=min_count, size=size, window=window, sg=1, trim_rule=rule)
    model.build_vocab(sentences)
    model.train(sentences)
    model.trim_rule = None  # so we can save
    model.save(output_path)
```
