### PR TITLE
remove setup.cfg file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[wheel]
-universal = 1


### PR DESCRIPTION
We shouldn't build universal wheels for gensim because gensim provides C extensions. 
See http://pythonwheels.com/: 

> Warning: If your project has optional C extensions, it is recommended not to publish a universal wheel, because pip will prefer the wheel over a source installation.