### PR TITLE
error-log instead of assert shape-check in save_word2vec_format

### DIFF
--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -956,7 +956,8 @@ class Word2Vec(utils.SaveLoad):
                 for word, vocab in sorted(iteritems(self.vocab), key=lambda item: -item[1].count):
                     vout.write(utils.to_utf8("%s %s\n" % (word, vocab.count)))
         logger.info("storing %sx%s projection weights into %s" % (len(self.vocab), self.vector_size, fname))
-        assert (len(self.vocab), self.vector_size) == self.syn0.shape
+        if not (len(self.vocab), self.vector_size) == self.syn0.shape:
+            logger.error("syn0.shape doesn't match vocab size & dimensions")
         with utils.smart_open(fname, 'wb') as fout:
             fout.write(utils.to_utf8("%s %s\n" % self.syn0.shape))
             # store in sorted order: most frequent words at the top


### PR DESCRIPTION
Change assert that to ERROR-level logging; some custom optimizations (loading vocab from elsewhere) might legitimately cause mismatch (which would normally be a problem).