### PR TITLE
LDA: initialisation of expElogbeta fixed

### DIFF
--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -308,7 +308,8 @@ class LdaModel(interfaces.TransformationABC):
         # Initialize the variational distribution q(beta|lambda)
         self.state = LdaState(self.eta, (self.num_topics, self.num_terms))
         self.state.sstats = numpy.random.gamma(100., 1. / 100., (self.num_topics, self.num_terms))
-        self.sync_state()
+        self.expElogbeta = numpy.exp(dirichlet_expectation(self.state.sstats))
+
 
         # if a training corpus was provided, start estimating the model right away
         if corpus is not None:

--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -310,7 +310,6 @@ class LdaModel(interfaces.TransformationABC):
         self.state.sstats = numpy.random.gamma(100., 1. / 100., (self.num_topics, self.num_terms))
         self.expElogbeta = numpy.exp(dirichlet_expectation(self.state.sstats))
 
-
         # if a training corpus was provided, start estimating the model right away
         if corpus is not None:
             self.update(corpus)


### PR DESCRIPTION
Fixing the initial value of expElogbeta to be in line with original Hoffmann implementation.