### PR TITLE
Update test_keywords.py

### DIFF
--- a/gensim/test/test_keywords.py
+++ b/gensim/test/test_keywords.py
@@ -48,7 +48,22 @@ class TestKeywordsTest(unittest.TestCase):
         generated_keywords = keywords(text, words=15, split=True)
 
         self.assertEqual(len(generated_keywords), 16)
+    
+    def test_keywords_ratio(self):
+   
+        pre_path = os.path.join(os.path.dirname(__file__), 'test_data')
 
+        with utils.smart_open(os.path.join(pre_path, "mihalcea_tarau.txt"), mode="r") as f:
+            text = f.read()
+
+        # Check ratio parameter is well behaved.  Because length is taken on tokenized clean text
+        # we just check that ratio 20% is twice as long as ratio 10%
+        # Values of 10% and 20% were carefully selected for this test to avoid
+        # numerical instabilities when several keywords have almost the same score
+        selected_docs_12 = keywords(text, ratio=0.1, split=True)
+        selected_docs_21 = keywords(text, ratio=0.2, split=True)
+
+        self.assertAlmostEqual(float(len(selected_docs_21))/len(selected_docs_12), float(21)/12, places=1)
 
     def test_text_summarization_raises_exception_on_short_input_text(self):
         pre_path = os.path.join(os.path.dirname(__file__), 'test_data')


### PR DESCRIPTION
A part of #441 . Updated ratio parameters specifically for this example.
Previous cutoff values were sensitive to numerical issues i.e. in the plateaus of this graph.
![scores](https://cloud.githubusercontent.com/assets/1261528/10343991/be4368a6-6d18-11e5-9698-81d5aa89040d.png)
