### PR TITLE
sparse2full: Issue #477 fixup

### DIFF
--- a/gensim/matutils.py
+++ b/gensim/matutils.py
@@ -205,6 +205,7 @@ def sparse2full(doc, length):
     """
     result = numpy.zeros(length, dtype=numpy.float32) # fill with zeroes (default value)
     doc = dict(doc)
+    doc = dict((k, v) for (k, v) in doc.items() if k < length)
     # overwrite some of the zeroes with explicit values
     result[list(doc)] = list(itervalues(doc))
     return result


### PR DESCRIPTION
Added check in `matutils.py` method `sparse2full` to only allow indices up to `length`. Fixing issue #477.