### PR TITLE
MAINT possible to use wheelhouse-uploader

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,8 @@
+[wheelhouse_uploader]
+artifact_indexes=
+    # OSX wheels built by travis (only for specific tags):
+    # https://github.com/MacPython/scikit-learn-wheels
+    http://wheels.scipy.org
+    # Windows wheels buit by:
+    # https://ci.appveyor.com/project/tmylk/gensim-ahs80
+    http://windows-wheels.scikit-learn.org/

--- a/setup.py
+++ b/setup.py
@@ -107,6 +107,13 @@ def readfile(fname):
 
 model_dir = os.path.join(os.path.dirname(__file__), 'gensim', 'models')
 
+cmdclass = {'build_ext': custom_build_ext}
+
+WHEELHOUSE_UPLOADER_COMMANDS = set(['fetch_artifacts', 'upload_all'])
+if WHEELHOUSE_UPLOADER_COMMANDS.intersection(sys.argv):
+    import wheelhouse_uploader.cmd
+    cmdclass.update(vars(wheelhouse_uploader.cmd))
+
 setup(
     name='gensim',
     version='0.12.2',
@@ -121,7 +128,7 @@ setup(
             sources=['./gensim/models/doc2vec_inner.c'],
             include_dirs=[model_dir]),
     ],
-    cmdclass={'build_ext': custom_build_ext},
+    cmdclass=cmdclass,
     packages=find_packages(),
 
     author=u'Radim Řehůřek',


### PR DESCRIPTION
Copied from https://github.com/scikit-learn/scikit-learn/pull/4028

--
wheelhouse-uploader makes it possible to leverage our CI infrastructure
(travis and appveyor) to automate the generation of binary packages
for OSX and windows (both .exe and .whl packages).

Adding those lines in setup.py make is easy for the release manager
to collect all the prebuilt binary packages (more than 10) that match a specific release
and upload them all at once to PyPI.

The cloud containers that are used to store the build artifacts of the
CI workers are configured in the setup.cfg file.

More details at: https://github.com/ogrisel/wheelhouse-uploader

The module is not imported unless you execute the following release command:
``
python setup.py sdist fetch_artifacts upload_all
``