### PR TITLE
LDAModel depracation warning (issue 494)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,18 @@ NEXT
   and `LdaMulticore` that may be reliant on the old tuple layout of
   `(probability, word)`.
 
+* Forwards compatibility for  NumPy > 1.10 (Matti Lyra, #494)
+  - LdaModel and LdaMulticore produce a large number of DepracationWarnings from
+    .inference() because the term ids in each chunk returned from utils.grouper
+    are floats. This behaviour has been changed so that the term IDs are now ints.
+  - utils.grouper returns a python list instead of a numpy array in .update() when
+    LdaModel is called in non distributed mode
+  - in distributed mode .update() will still call utils.grouper with as_numpy=True
+    to save memory
+  - LdaModel.update and LdaMulticore.update have a new keyword parameter
+    chunks_as_numpy=True/False (defaults to False) that allows controlling
+    this behaviour.
+
 0.12.2, 19/09/2015
 
 * tutorial on text summarization (Ólavur Mortensen, #436)

--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -368,6 +368,8 @@ class LdaModel(interfaces.TransformationABC):
         # to Blei's original LDA-C code, cool!).
         for d, doc in enumerate(chunk):
             if isinstance(doc, numpy.ndarray):
+                if len(doc) == 0:
+                    continue
                 ids = doc[:, 0].astype(numpy.int_)
                 cts = doc[:, 1]
             else:

--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -367,8 +367,12 @@ class LdaModel(interfaces.TransformationABC):
         # Lee&Seung trick which speeds things up by an order of magnitude, compared
         # to Blei's original LDA-C code, cool!).
         for d, doc in enumerate(chunk):
-            ids = [id for id, _ in doc]
-            cts = numpy.array([cnt for _, cnt in doc])
+            if isinstance(doc, numpy.ndarray):
+                ids = doc[:, 0].astype(numpy.int_)
+                cts = doc[:, 1]
+            else:
+                ids = [id for id, _ in doc]
+                cts = numpy.array([cnt for _, cnt in doc])
             gammad = gamma[d, :]
             Elogthetad = Elogtheta[d, :]
             expElogthetad = expElogtheta[d, :]

--- a/gensim/models/ldamulticore.py
+++ b/gensim/models/ldamulticore.py
@@ -141,7 +141,7 @@ class LdaMulticore(LdaModel):
             gamma_threshold=gamma_threshold)
 
 
-    def update(self, corpus):
+    def update(self, corpus, chunks_as_numpy=False):
         """
         Train the model with new documents, by EM-iterating over `corpus` until
         the topics converge (or until the maximum number of allowed iterations
@@ -221,7 +221,7 @@ class LdaMulticore(LdaModel):
                     if self.eval_every is not None and ((force and queue_size[0] == 0) or (self.eval_every != 0 and (self.num_updates / updateafter) % self.eval_every == 0)):
                         self.log_perplexity(chunk, total_docs=lencorpus)
 
-            chunk_stream = utils.grouper(corpus, self.chunksize, as_numpy=True)
+            chunk_stream = utils.grouper(corpus, self.chunksize, as_numpy=chunks_as_numpy)
             for chunk_no, chunk in enumerate(chunk_stream):
                 reallen += len(chunk)  # keep track of how many documents we've processed so far
 


### PR DESCRIPTION
I decided to not call `utils.grouper` with `as_numpy=False` and break the Pyro stuff as I thought we can work around that. So now there's just a check in `.inference` that makes sure the indices are `ints` when a numpy array is passed in.

This seemed like a better choice as it doesn't introduce any breaking changes unnecessarily.