### PR TITLE
fixes #484 and #485: id2word does not need to be a Dictionary and making read_doc_topics compatible with Mallet2.0.8

### DIFF
--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -838,10 +838,11 @@ class LdaModel(interfaces.TransformationABC):
             for m in top_words[1:]:
                 # m_docs is v_m^(t)
                 m_docs = doc_word_list[m]
+                m_index = numpy.where(top_words == m)[0]
 
                 # Sum of top words l=1..m-1
                 # i.e., all words ranked higher than the current word m
-                for l in top_words[:m - 1]:
+                for l in top_words[:m_index - 1]:
                     # l_docs is v_l^(t)
                     l_docs = doc_word_list[l]
 


### PR DESCRIPTION
#484 :  to resolve this, created word2id dictionary by reversing id2word and from there it is easy to get tokenid by calling word2id on the particular token you want.  This should work even if id2word is not provided as this line (https://github.com/piskvorky/gensim/blob/develop/gensim/models/wrappers/ldamallet.py#L83) takes care of that at the very beginning.

#485 :  to resolve this, made `read_doctopics()` a def for LdaMallet class.  We read the first line of the file, and check whether it started with '#doc ' (Mallet 2.0.7), then we skip the header line as before.  If there is no header line however (Mallet 2.0.8), we do not skip the first line.  The next change involved checking the number of items in each line to see whether the file contains 'topic#  probability' ordering (Mallet 2.0.7) or just 'probabilities' (ordered by increasing topic# as in Mallet 2.0.8). After this check, doc probabilities are obtained accordingly.

#517 :  modified `top_topics()` in ldamodel.py to account for coherence score correctly.