### PR TITLE
Provide INPUT_MIN_LENGTH in docstring

### DIFF
--- a/gensim/summarization/summarizer.py
+++ b/gensim/summarization/summarizer.py
@@ -132,7 +132,7 @@ def summarize_corpus(corpus, ratio=0.2):
     """
     Returns a list of the most important documents of a corpus using a
     variation of the TextRank algorithm.
-    The input must have at least INPUT_MIN_LENGTH ({}) documents for the
+    The input must have at least INPUT_MIN_LENGTH (%d) documents for the
     summary to make sense.
 
     The length of the output can be specified using the ratio parameter,
@@ -142,7 +142,7 @@ def summarize_corpus(corpus, ratio=0.2):
     The most important documents are returned as a list sorted by the
     document score, highest first.
 
-    """.format(INPUT_MIN_LENGTH)
+    """ % INPUT_MIN_LENGTH
     hashable_corpus = _build_hasheable_corpus(corpus)
 
     # If the corpus is empty, the function ends.

--- a/gensim/summarization/summarizer.py
+++ b/gensim/summarization/summarizer.py
@@ -137,7 +137,7 @@ def summarize_corpus(corpus, ratio=0.2):
 
     The length of the output can be specified using the ratio parameter,
     which determines how many documents will be chosen for the summary
-    (defaults at 20% of the number of documents of the corpus).
+    (defaults at 20%% of the number of documents of the corpus).
 
     The most important documents are returned as a list sorted by the
     document score, highest first.

--- a/gensim/summarization/summarizer.py
+++ b/gensim/summarization/summarizer.py
@@ -132,7 +132,7 @@ def summarize_corpus(corpus, ratio=0.2):
     """
     Returns a list of the most important documents of a corpus using a
     variation of the TextRank algorithm.
-    The input must have at least INPUT_MIN_LENGTH documents for the
+    The input must have at least INPUT_MIN_LENGTH ({}) documents for the
     summary to make sense.
 
     The length of the output can be specified using the ratio parameter,
@@ -142,7 +142,7 @@ def summarize_corpus(corpus, ratio=0.2):
     The most important documents are returned as a list sorted by the
     document score, highest first.
 
-    """
+    """.format(INPUT_MIN_LENGTH)
     hashable_corpus = _build_hasheable_corpus(corpus)
 
     # If the corpus is empty, the function ends.


### PR DESCRIPTION
Give users quick access to the minimum number of documents needed 
by summarize_corpus. Use string formatting at runtime in case the value
of INPUT_MIN_LENGTH is changed.