### PR TITLE
fixed #449 removed loading of structures that are not necessary

### DIFF
--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -1466,7 +1466,7 @@ class Word2Vec(utils.SaveLoad):
         for v in model.vocab.values():
             if hasattr(v, 'sample_int'):
                 break  # already 0.12.0+ style int probabilities
-            else:
+            elif hasattr(v, 'sample_probability'):
                 v.sample_int = int(round(v.sample_probability * 2**32))
                 del v.sample_probability
         if not hasattr(model, 'syn0_lockf') and hasattr(model, 'syn0'):


### PR DESCRIPTION
This PR proposes fix for the issue #499. Thanks to this modification it will be now possible to load even object that was pickled without at least for inference unnecessary `model.vocab.values[n].sample_probability` values. 

These kind of models can be obtained simply by loading the model via `load_word2vec_format("model.txt")`, `save("model.pkl")` and `load("model.pkl")` sequence of commands.