### PR TITLE
Flexible API for nearest neighbour search

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,11 +1,7 @@
 Changes
 =======
 
-* Loading of pattern library in utils.py is only in lemmatize function (Jan Zikes, #461)
-  - utils.HAS_PATTERN, has also changed to utils.has_pattern()
-* Word2vec allows non-strict unicode error handling (ignore or replace). (Gordon Mohr, #466)
-
-0.12.3, 05/11/2015
+0.12.3, 06/11/2015
 
 * Make show_topics return value consistent across models (Christopher Corley, #448)
   - All models with the `show_topics` method should return a list of

--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -404,7 +404,7 @@ class DocvecsArray(utils.SaveLoad):
                     self.doctag_syn0norm = empty(self.doctag_syn0.shape, dtype=REAL)
                 np_divide(self.doctag_syn0, sqrt((self.doctag_syn0 ** 2).sum(-1))[..., newaxis], self.doctag_syn0norm)
 
-    def most_similar(self, positive=[], negative=[], topn=10, clip_start=0, clip_end=None):
+    def most_similar(self, positive=[], negative=[], topn=10, clip_start=0, clip_end=None, indexer=None):
         """
         Find the top-N most similar docvecs known from training. Positive docs contribute
         positively towards the similarity, negative docs negatively.
@@ -417,6 +417,8 @@ class DocvecsArray(utils.SaveLoad):
         The 'clip_start' and 'clip_end' allow limiting results to a particular contiguous
         range of the underlying doctag_syn0norm vectors. (This may be useful if the ordering
         there was chosen to be significant, such as more popular tag IDs in lower indexes.)
+
+	The 'indexer' is any instance of NeighborIndexer which speeds up the search process.
         """
         self.init_sims()
         clip_end = clip_end or len(self.doctag_syn0norm)
@@ -448,6 +450,9 @@ class DocvecsArray(utils.SaveLoad):
         if not mean:
             raise ValueError("cannot compute similarity with no input")
         mean = matutils.unitvec(array(mean).mean(axis=0)).astype(REAL)
+
+        if indexer is not None:
+            return indexer.get_nearest_items(mean, top_n=topn)
 
         dists = dot(self.doctag_syn0norm[clip_start:clip_end], mean)
         if not topn:

--- a/gensim/models/neighbor_sim.py
+++ b/gensim/models/neighbor_sim.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from doc2vec import Doc2Vec
+from word2vec import Word2Vec
+
+from annoy import AnnoyIndex
+
+"""
+Using 3rd party k-NN libraries to improve performance for method DocvecsArray.most_similar().
+
+More information can be found at: https://github.com/piskvorky/gensim/wiki/Ideas-&-Feature-proposals#integrate-a-fast-k-nn-library
+
+Implemented by: Anh Le (anhldbk@gmail.com)
+
+Website: http://bigsonata.com
+
+Release 1: November 2015
+"""
+
+
+class NeighborIndexer(object):
+    """
+    Base class for k-NN libraries
+    """
+
+    def __init__(self, model=None, **kwargs):
+        """
+        Create a new indexer
+        :param model:   Instance of Doc2Vec or Word2Vec
+        :param kwargs:  Additional named parameters
+        """
+        if model is None:
+            raise Exception("Invalid model parameter. Please provide model with an instance of Doc2Vec or Word2Vec")
+        if type(model) is Doc2Vec:
+            self._init_doc2vec_(model)
+        elif type(model) is Word2Vec:
+            self._init_word2vec_(model)
+        else:
+            raise Exception("Invalid model parameter. Please provide model with an instance of Doc2Vec or Word2Vec")
+        self.start_indexing()
+
+    def _init_doc2vec_(self, model):
+        docvecs = model.docvecs
+        docvecs.init_sims()
+        size = len(docvecs.doctag_syn0norm)
+
+        for i in range(size):
+            self.add_item(docvecs.offset2doctag[i], docvecs.doctag_syn0norm[i])
+
+    def _init_word2vec_(self, model):
+        # raise Exception("Not supported at the moment")
+        model.init_sims()
+        size = len(model.syn0norm)
+
+        for i in range(size):
+            self.add_item(model.index2word[i], model.syn0norm[i])
+
+    def get_item(self, label):
+        """
+        Get an item's vector by its label
+        :param label: The label
+        :return: The item's vector if have. Otherwise, returns None
+        """
+        pass
+
+    def add_item(self, label, vector):
+        """
+        Add an item to index
+        :param label: the label of the item (must be unique).
+        :param vector: the item's vector.
+        """
+        pass
+
+    def start_indexing(self):
+        """
+        Start the indexing operation. This method is supposed to run after all items are added
+        It may take time to finish.
+        """
+        pass
+
+    def get_nearest_items(self, vector, top_n=10):
+        """
+        Get nearest items for an item described by its vector
+        :param	vector: The vector
+        :param	top_n: Number of nearest items to get
+        :return	A list of tuples (label, similarity) for the nearest ones
+        """
+        pass
+
+    def save(self, file_name):
+        """
+        Dump internal data into disk
+        :param file_name:   Output file path
+        :return: Returns true on success. Otherwise, returns false
+        """
+        pass
+
+    def load(self, file_name):
+        """
+        Load previously dumped info
+        :param file_name:  Input file paht
+        :return: Returns true on success. Otherwise, returns false
+        """
+        pass
+
+
+class AnnoyIndexer(NeighborIndexer):
+    """
+    An Annoy-based indexer
+    """
+
+    def __init__(self, model=None, **kwargs):
+        """
+        Constructor
+        :param features_num: Number of features
+        """
+        if "features_num" not in kwargs:
+            raise Exception("Not enough parameter")
+        self.features_num = kwargs["features_num"]
+
+        if "tree_size" not in kwargs:
+            raise Exception("Not enough parameter")
+        self.tree_size = kwargs["tree_size"]
+
+        self.annoy_indexer = AnnoyIndex(self.features_num)  # Length of item vector that will be indexed
+        self.index_label_dict = {}
+        self.label_index_dict = {}
+        self.id = 0
+
+        # call parent constructor
+        super(AnnoyIndexer, self).__init__(model, **kwargs)
+
+    def add_item(self, label, vector):
+        """
+        Add an item to index
+        :param label: is the label of the item.
+        :param vector: is the item's vector.
+        """
+        self.index_label_dict[self.id] = label
+        self.label_index_dict[label] = self.id
+        self.annoy_indexer.add_item(self.id, vector)
+        self.id += 1
+
+    def get_item(self, label):
+        """
+        Get an item's vector by its label
+        :param label: The label
+        :return: The item's vector if have. Otherwise, returns None
+        """
+        if label not in self.label_index_dict:
+            return None
+        return self.annoy_indexer.get_item_vector(self.label_index_dict[label])
+
+    def start_indexing(self):
+        """
+        Start the indexing operation. This method is supposed to run after all items are added
+        It may take time to finish
+        """
+        self.annoy_indexer.build(self.tree_size)
+
+    def get_nearest_items(self, vector, top_n=10):
+        """
+        Get nearest items for an item described by its vector
+        :param	vector: The vector
+        :param	top_n: Number of nearest items to get
+        :return	A list of tuples (label, similarity) for the nearest ones
+        """
+        nearest = self.annoy_indexer.get_nns_by_vector(vector, top_n, include_distances=True)
+        size = len(nearest[0])
+
+        # By default, Annoy uses Cosine Distance
+        # Reference: http://docs.scipy.org/doc/scipy-0.16.0/reference/generated/scipy.spatial.distance.cosine.html
+        # To get the similarity, we use the formula: similarity = 1 - cosine_distance/2
+        result = []
+        for index in range(size):
+            label = self.index_label_dict[nearest[0][index]]
+            similarity = 1 - nearest[1][index] / 2
+            result += [(label, similarity)]
+
+        return result
+
+    def save(self, file_name):
+        """
+        Dump internal data into disk
+        :param file_name:   Output file path
+        :return: Returns true on success. Otherwise, returns false
+        """
+        try:
+            self.annoy_indexer.save(file_name)
+            return True
+        except Exception as e:
+            return False
+
+    def load(self, file_name):
+        """
+        Load previously dumped info
+        :param file_name:  Input file paht
+        :return: Returns true on success. Otherwise, returns false
+        """
+        try:
+            self.annoy_indexer.load(file_name)
+            return True
+        except Exception as e:
+            return False

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -1123,7 +1123,7 @@ class Word2Vec(utils.SaveLoad):
                         self.syn0[self.vocab[word].index] = weights
         logger.info("merged %d vectors into %s matrix from %s" % (overlap_count, self.syn0.shape, fname))
 
-    def most_similar(self, positive=[], negative=[], topn=10, restrict_vocab=None):
+    def most_similar(self, positive=[], negative=[], topn=10, restrict_vocab=None, indexer=None):
         """
         Find the top-N most similar words. Positive words contribute positively towards the
         similarity, negative words negatively.
@@ -1139,6 +1139,8 @@ class Word2Vec(utils.SaveLoad):
         are searched for most-similar values. For example, restrict_vocab=10000 would
         only check the first 10000 word vectors in the vocabulary order. (This may be
         meaningful if you've sorted the vocabulary by descending frequency.)
+
+	The 'indexer' is any instance of NeighborIndexer which speeds up the search process.
 
         Example::
 
@@ -1175,6 +1177,9 @@ class Word2Vec(utils.SaveLoad):
         if not mean:
             raise ValueError("cannot compute similarity with no input")
         mean = matutils.unitvec(array(mean).mean(axis=0)).astype(REAL)
+
+        if indexer is not None:
+            return indexer.get_nearest_items(mean, top_n=topn)
 
         limited = self.syn0norm if restrict_vocab is None else self.syn0norm[:restrict_vocab]
         dists = dot(limited, mean)


### PR DESCRIPTION
This is an implementation for issue [#527](https://github.com/piskvorky/gensim/issues/527)

I've added neighbor_sim.py in directory gensim/models in which I defined NeighborIndexer classes.
```python
class NeighborIndexer(object):
    """
    Base class for k-NN libraries
    """

    def __init__(self, model=None, **kwargs):
        """
        Create a new indexer
        :param model:   Instance of Doc2Vec or Word2Vec
        :param kwargs:  Additional named parameters
        """
        if model is None:
            raise Exception("Invalid model parameter. Please provide model with an instance of Doc2Vec or Word2Vec")
        if type(model) is Doc2Vec:
            self._init_doc2vec_(model)
        elif type(model) is Word2Vec:
            self._init_word2vec_(model)
        else:
            raise Exception("Invalid model parameter. Please provide model with an instance of Doc2Vec or Word2Vec")
        self.start_indexing()

    def _init_doc2vec_(self, model):
        docvecs = model.docvecs
        docvecs.init_sims()
        size = len(docvecs.doctag_syn0norm)

        for i in range(size):
            self.add_item(docvecs.offset2doctag[i], docvecs.doctag_syn0norm[i])

    def _init_word2vec_(self, model):
        # raise Exception("Not supported at the moment")
        model.init_sims()
        size = len(model.syn0norm)

        for i in range(size):
            self.add_item(model.index2word[i], model.syn0norm[i])

    def get_item(self, label):
        """
        Get an item's vector by its label
        :param label: The label
        :return: The item's vector if have. Otherwise, returns None
        """
        pass

    def add_item(self, label, vector):
        """
        Add an item to index
        :param label: the label of the item (must be unique).
        :param vector: the item's vector.
        """
        pass

    def start_indexing(self):
        """
        Start the indexing operation. This method is supposed to run after all items are added
        It may take time to finish.
        """
        pass

    def get_nearest_items(self, vector, top_n=10):
        """
        Get nearest items for an item described by its vector
        :param	vector: The vector
        :param	top_n: Number of nearest items to get
        :return	A list of tuples (label, similarity) for the nearest ones
        """
        pass

    def save(self, file_name):
        """
        Dump internal data into disk
        :param file_name:   Output file path
        :return: Returns true on success. Otherwise, returns false
        """
        pass

    def load(self, file_name):
        """
        Load previously dumped info
        :param file_name:  Input file paht
        :return: Returns true on success. Otherwise, returns false
        """
        pass
```
To make the integration process easier, I've modified most_similar() functions in doc2vec.py and word2vec.py by adding optional parameter *indexer*

For example: 
```python
# at line #409, doc2vec.py, the new function looks like this
def most_similar(self, positive=[], negative=[], topn=10, clip_start=0, clip_end=None, indexer=None):
```

To use the indexers, you may use the snippet below:
```python
from gensim.models.neighbor_sim import AnnoyIndexer
model = Doc2Vec.load(fname)

# create an indexer 
# features_num  = size of each document's vector
# You may need to optimize your *tree_size* parameter
indexer = AnnoyIndexer(model=model, features_num=100, tree_size=300)

# it may take time to finish the indexing operation

document = "Here comes the sun"
vector = model.features_num(document.lower().split())

# get most similar documents
similar_documents = model.most_similar([vector], indexer=indexer)
```

Currently, only Annoy-based NeighborIndexer is supported.

