### PR TITLE
Minor lda refactoring

### DIFF
--- a/gensim/models/ldamulticore.py
+++ b/gensim/models/ldamulticore.py
@@ -51,6 +51,8 @@ import logging
 
 from gensim import utils
 from gensim.models.ldamodel import LdaModel, LdaState
+
+import six
 from six.moves import queue, xrange
 from multiprocessing import Pool, Queue, cpu_count
 
@@ -133,8 +135,10 @@ class LdaMulticore(LdaModel):
         """
         self.workers = max(1, cpu_count() - 1) if workers is None else workers
         self.batch = batch
-        if alpha == 'auto':
+
+        if isinstance(alpha, six.string_types) and alpha == 'auto':
             raise NotImplementedError("auto-tuning alpha not implemented in multicore LDA; use plain LdaModel.")
+
         super(LdaMulticore, self).__init__(corpus=corpus, num_topics=num_topics,
             id2word=id2word, chunksize=chunksize, passes=passes, alpha=alpha, eta=eta,
             decay=decay, offset=offset, eval_every=eval_every, iterations=iterations,

--- a/gensim/test/test_ldamodel.py
+++ b/gensim/test/test_ldamodel.py
@@ -121,6 +121,11 @@ class TestLdaModel(unittest.TestCase):
         self.assertEqual(model.alpha.shape, expected_shape)
         self.assertTrue(all(model.alpha == numpy.array([0.3, 0.3])))
 
+        kwargs['alpha'] = numpy.array([0.3, 0.3])
+        model = self.class_(**kwargs)
+        self.assertEqual(model.alpha.shape, expected_shape)
+        self.assertTrue(all(model.alpha == numpy.array([0.3, 0.3])))
+
         # all should raise an exception for being wrong shape
         kwargs['alpha'] = [0.3, 0.3, 0.3]
         self.assertRaises(AssertionError, self.class_, **kwargs)
@@ -181,6 +186,11 @@ class TestLdaModel(unittest.TestCase):
         self.assertTrue(all(model.eta == numpy.array([[0.3], [0.3]])))
 
         kwargs['eta'] = [0.3, 0.3]
+        model = self.class_(**kwargs)
+        self.assertEqual(model.eta.shape, expected_shape)
+        self.assertTrue(all(model.eta == numpy.array([[0.3], [0.3]])))
+
+        kwargs['eta'] = numpy.array([0.3, 0.3])
         model = self.class_(**kwargs)
         self.assertEqual(model.eta.shape, expected_shape)
         self.assertTrue(all(model.eta == numpy.array([[0.3], [0.3]])))


### PR DESCRIPTION
A few small changes to LdaMallet from my comments on #516.

Importantly, changes to handling alpha/eta setting in LdaModel. Numpy 1.10.1 was throwing FutureWarnings on string comparisons to the array. init_dir_prior is more explicit about this now.