### PR TITLE
Allow build_vocab to take progress_per parameter

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,8 @@
 Changes
 =======
 
+* build_vocab takes progress_per parameter for smaller output (@zer0n, #624)
+
 0.12.4, 29/01/2016
 
 * Better internal handling of job batching in word2vec (#535)

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -499,13 +499,13 @@ class Word2Vec(utils.SaveLoad):
 
             logger.info("built huffman tree with maximum node depth %i", max_depth)
 
-    def build_vocab(self, sentences, keep_raw_vocab=False, trim_rule=None):
+    def build_vocab(self, sentences, keep_raw_vocab=False, trim_rule=None, progress_per=10000):
         """
         Build vocabulary from a sequence of sentences (can be a once-only generator stream).
         Each sentence must be a list of unicode strings.
 
         """
-        self.scan_vocab(sentences, trim_rule=trim_rule)  # initial survey
+        self.scan_vocab(sentences, progress_per=progress_per, trim_rule=trim_rule)  # initial survey
         self.scale_vocab(keep_raw_vocab=keep_raw_vocab, trim_rule=trim_rule)  # trim by min_count & precalculate downsampling
         self.finalize_vocab()  # build tables & arrays
 


### PR DESCRIPTION
Otherwise, it would print out too many lines when training on datasets such as Wikipedia.