### PR TITLE
[MRG] ENH: Make normalization an explicit transformation.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,7 @@
 Changes
 =======
 0.12.5, 2016
+* Made normalization an explicit transformation. Added 'l1' norm support (Devashish Deshpande, #649)
 * added term-topics API for most probable topic for word in vocab. (@bhargavvader, #706)
 * build_vocab takes progress_per parameter for smaller output (@zer0n, #624)
 * Control whether to use lowercase for computing word2vec accuracy. (@alantian, #607)

--- a/docs/src/models/normmodel.rst
+++ b/docs/src/models/normmodel.rst
@@ -1,0 +1,9 @@
+:mod:`models.normmodel` -- Normalization model
+===============================================
+
+.. automodule:: gensim.models.normmodel
+    :synopsis: Normalization model
+    :members:
+    :inherited-members:
+    :undoc-members:
+    :show-inheritance:

--- a/gensim/models/__init__.py
+++ b/gensim/models/__init__.py
@@ -14,6 +14,7 @@ from .word2vec import Word2Vec
 from .doc2vec import Doc2Vec
 from .ldamulticore import LdaMulticore
 from .phrases import Phrases
+from .normmodel import NormModel
 
 from . import wrappers
 

--- a/gensim/models/normmodel.py
+++ b/gensim/models/normmodel.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2012 Radim Rehurek <radimrehurek@seznam.cz>
+# Licensed under the GNU LGPL v2.1 - http://www.gnu.org/licenses/lgpl.html
+
+import logging
+
+from gensim import interfaces, matutils
+
+logger = logging.getLogger(__name__)
+
+
+class NormModel(interfaces.TransformationABC):
+    """
+    Objects of this class realize the explicit normalization of
+    vectors. Supported norms are l1' and 'l2' with 'l2' being
+    default.
+
+    The main methods are:
+
+    1. Constructor which normalizes the terms in the given corpus document-wise.
+    2. The normalize() method which normalizes a simple count representation.
+    3. The [] transformation which internally calls the self.normalize() method.
+
+    >>> norm_l2 = NormModel(corpus)
+    >>> print(norm_l2[some_doc])
+    >>> norm_l2.save('/tmp/foo.tfidf_model')
+
+    Model persistency is achieved via its load/save methods
+    """
+    def __init__(self, corpus=None, norm='l2'):
+        """
+        Compute the 'l1' or 'l2' normalization by normalizing separately
+        for each doc in a corpus.
+        Formula for 'l1' norm for term 'i' in document 'j' in a corpus of 'D' documents is::
+
+          norml1_{i, j} = (i / sum(absolute(values in j)))
+
+        Formula for 'l2' norm for term 'i' in document 'j' in a corpus of 'D' documents is::
+
+          norml2_{i, j} = (i / sqrt(sum(square(values in j))))
+        """
+        self.norm = norm
+        if corpus is not None:
+            self.calc_norm(corpus)
+        else:
+            pass
+
+    def __str__(self):
+        return "NormModel(num_docs=%s, num_nnz=%s, norm=%s)" % (self.num_docs, self.num_nnz, self.norm)
+
+    def calc_norm(self, corpus):
+        """
+        Calculates the norm by calling matutils.unitvec with the norm parameter.
+        """
+        logger.info("Performing %s normalization..." % (self.norm))
+        norms = []
+        numnnz = 0
+        docno = 0
+        for bow in corpus:
+            docno += 1
+            numnnz += len(bow)
+            norms.append(matutils.unitvec(bow, self.norm))
+        self.num_docs = docno
+        self.num_nnz = numnnz
+        self.norms = norms
+
+    def normalize(self, bow):
+        vector = matutils.unitvec(bow, self.norm)
+        return vector
+
+    def __getitem__(self, bow):
+        return self.normalize(bow)
+#endclass NormModel

--- a/gensim/test/test_normmodel.py
+++ b/gensim/test/test_normmodel.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2010 Radim Rehurek <radimrehurek@seznam.cz>
+# Licensed under the GNU LGPL v2.1 - http://www.gnu.org/licenses/lgpl.html
+
+"""
+Automated tests for checking transformation algorithms (the models package).
+"""
+
+
+import logging
+import unittest
+import os
+import os.path
+import tempfile
+
+import numpy
+from scipy.sparse import csr_matrix
+from scipy.sparse import issparse
+
+from gensim.corpora import mmcorpus
+from gensim.models import normmodel
+
+module_path = os.path.dirname(__file__) # needed because sample data files are located in the same folder
+datapath = lambda fname: os.path.join(module_path, 'test_data', fname)
+
+
+def testfile():
+    # temporary data will be stored to this file
+    return os.path.join(tempfile.gettempdir(), 'gensim_models.tst')
+
+
+class TestNormModel(unittest.TestCase):
+    def setUp(self):
+        self.corpus = mmcorpus.MmCorpus(datapath('testcorpus.mm'))
+        # Choose doc to be normalized. [3] chosen to demonstrate different results for l1 and l2 norm.
+        # doc is [(1, 1.0), (5, 2.0), (8, 1.0)]
+        self.doc = list(self.corpus)[3]
+        self.model_l1 = normmodel.NormModel(self.corpus, norm='l1')
+        self.model_l2 = normmodel.NormModel(self.corpus, norm='l2')
+
+    def test_tupleInput_l1(self):
+        """Test tuple input for l1 transformation"""
+        normalized = self.model_l1.normalize(self.doc)
+        expected = [(1, 0.25), (5, 0.5), (8, 0.25)]
+        self.assertTrue(numpy.allclose(normalized, expected))
+
+    def test_sparseCSRInput_l1(self):
+        """Test sparse csr matrix input for l1 transformation"""
+        row = numpy.array([0, 0, 1, 2, 2, 2])
+        col = numpy.array([0, 2, 2, 0, 1, 2])
+        data = numpy.array([1, 2, 3, 4, 5, 6])
+        sparse_matrix = csr_matrix((data, (row, col)), shape=(3, 3))
+        normalized = self.model_l1.normalize(sparse_matrix)
+
+        # Check if output is of same type
+        self.assertTrue(issparse(normalized))
+
+        # Check if output is correct
+        expected = numpy.array([[0.04761905, 0., 0.0952381],
+                                [0., 0., 0.14285714],
+                                [0.19047619, 0.23809524, 0.28571429]])
+        self.assertTrue(numpy.allclose(normalized.toarray(), expected))
+
+    def test_numpyndarrayInput_l1(self):
+        """Test for numpy ndarray input for l1 transformation"""
+        ndarray_matrix = numpy.array([[1, 0, 2],
+                                      [0, 0, 3],
+                                      [4, 5, 6]])
+        normalized = self.model_l1.normalize(ndarray_matrix)
+
+        # Check if output is of same type
+        self.assertTrue(isinstance(normalized, numpy.ndarray))
+
+        # Check if output is correct
+        expected = numpy.array([[0.04761905, 0., 0.0952381],
+                                [0., 0., 0.14285714],
+                                [0.19047619, 0.23809524, 0.28571429]])
+        self.assertTrue(numpy.allclose(normalized, expected))
+
+        # Test if error is raised on unsupported input type
+        self.assertRaises(ValueError, lambda model, doc: model.normalize(doc), self.model_l1, [1, 2, 3])
+
+    def test_tupleInput_l2(self):
+        """Test tuple input for l2 transformation"""
+        normalized = self.model_l2.normalize(self.doc)
+        expected = [(1, 0.4082482904638631), (5, 0.8164965809277261), (8, 0.4082482904638631)]
+        self.assertTrue(numpy.allclose(normalized, expected))
+
+    def test_sparseCSRInput_l2(self):
+        """Test sparse csr matrix input for l2 transformation"""
+        row = numpy.array([0, 0, 1, 2, 2, 2])
+        col = numpy.array([0, 2, 2, 0, 1, 2])
+        data = numpy.array([1, 2, 3, 4, 5, 6])
+        sparse_matrix = csr_matrix((data, (row, col)), shape=(3, 3))
+
+        normalized = self.model_l2.normalize(sparse_matrix)
+
+        # Check if output is of same type
+        self.assertTrue(issparse(normalized))
+
+        # Check if output is correct
+        expected = numpy.array([[0.10482848, 0., 0.20965697],
+                                [0., 0., 0.31448545],
+                                [0.41931393, 0.52414242, 0.6289709]])
+        self.assertTrue(numpy.allclose(normalized.toarray(), expected))
+
+    def test_numpyndarrayInput_l2(self):
+        """Test for numpy ndarray input for l2 transformation"""
+        ndarray_matrix = numpy.array([[1, 0, 2],
+                                      [0, 0, 3],
+                                      [4, 5, 6]])
+        normalized = self.model_l2.normalize(ndarray_matrix)
+
+        # Check if output is of same type
+        self.assertTrue(isinstance(normalized, numpy.ndarray))
+
+        # Check if output is correct
+        expected = numpy.array([[0.10482848, 0., 0.20965697],
+                                [0., 0., 0.31448545],
+                                [0.41931393, 0.52414242, 0.6289709]])
+        self.assertTrue(numpy.allclose(normalized, expected))
+
+        # Test if error is raised on unsupported input type
+        self.assertRaises(ValueError, lambda model, doc: model.normalize(doc), self.model_l2, [1, 2, 3])
+
+    def testInit(self):
+        """Test if error messages raised on unsupported norm"""
+        self.assertRaises(ValueError, normmodel.NormModel, self.corpus, 'l0')
+
+    def testPersistence(self):
+        fname = testfile()
+        model = normmodel.NormModel(self.corpus)
+        model.save(fname)
+        model2 = normmodel.NormModel.load(fname)
+        self.assertTrue(model.norms == model2.norms)
+        tstvec = []
+        self.assertTrue(numpy.allclose(model.normalize(tstvec), model2.normalize(tstvec))) # try projecting an empty vector
+
+    def testPersistenceCompressed(self):
+        fname = testfile() + '.gz'
+        model = normmodel.NormModel(self.corpus)
+        model.save(fname)
+        model2 = normmodel.NormModel.load(fname, mmap=None)
+        self.assertTrue(model.norms == model2.norms)
+        tstvec = []
+        self.assertTrue(numpy.allclose(model.normalize(tstvec), model2.normalize(tstvec))) # try projecting an empty vector
+
+
+if __name__ == '__main__':
+    logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s', level=logging.DEBUG)
+    unittest.main()


### PR DESCRIPTION
Addresses issue #69. What this PR includes:
* Added support for ''l1' norm.
* Added norm parameter to Similarity constructor.
* Added norm parameter to matutils.unitvec.
* Created file models/normmodel.py to make normalization an explicit transformation.

TODO:
- [X] Check for input validation
- [X] Make test file test/test_norms.py
- [X] Add tests for input validation using assertRaises
- [X] Add documentation
- [X] Add more tests to testTransform to cover all input type validations

@piskvorky @tmylk Could you please tell me if I'm going on the right track?