### PR TITLE
allow int/string type doc2vec tag

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,7 +1,7 @@
 Changes
 =======
 
-* Allow calls like TaggedDocument(words=words,tags='SENT1') or TaggedDocument(words=words,tags=1), as a shorthand for TaggedDocument(words=words,tags=['SENT1'])or TaggedDocument(words=words,tags=["1"]) (Hayate ISO, #651)
+* Allow calls like TaggedDocument(words=words,tags='SENT1') or TaggedDocument(words=words,tags=1), as a shorthand for TaggedDocument(words=words,tags=['SENT1']) or TaggedDocument(words=words,tags=['1']) (Hayate ISO, #651)
 
 0.12.4, 29/01/2016
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,8 @@
 Changes
 =======
 
+* Allow calls like TaggedDocument(words=words,tags='SENT1') or TaggedDocument(words=words,tags=1), as a shorthand for TaggedDocument(words=words,tags=['SENT1'])or TaggedDocument(words=words,tags=["1"]) (Hayate ISO, #651)
+
 0.12.4, 29/01/2016
 
 * Better internal handling of job batching in word2vec (#535)

--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -242,6 +242,9 @@ class TaggedDocument(namedtuple('TaggedDocument', 'words tags')):
 
     """
     def __str__(self):
+        if isinstance(self.tags, string_types):
+        # allow calls like TaggedDocument(words=words,tags='SENT_99'), as a shorthand for TaggedDocument(words=words,tags=['SENT_99']) 
+            self.tags = [self.tags]
         return '%s(%s, %s)' % (self.__class__.__name__, self.words, self.tags)
 
 

--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -245,6 +245,9 @@ class TaggedDocument(namedtuple('TaggedDocument', 'words tags')):
         if isinstance(self.tags, string_types):
         # allow calls like TaggedDocument(words=words,tags='SENT_99'), as a shorthand for TaggedDocument(words=words,tags=['SENT_99']) 
             self.tags = [self.tags]
+        elif isinstance(self.tags, integer_types):
+        # allow calls like TaggedDocument(words=words,tags=1), as a shorthand for TaggedDocument(words=words,tags=['1']) 
+            self.tags = [str(self.tags)]
         return '%s(%s, %s)' % (self.__class__.__name__, self.words, self.tags)
 
 

--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -242,12 +242,9 @@ class TaggedDocument(namedtuple('TaggedDocument', 'words tags')):
 
     """
     def __str__(self):
-        if isinstance(self.tags, string_types):
-        # allow calls like TaggedDocument(words=words,tags='SENT_99'), as a shorthand for TaggedDocument(words=words,tags=['SENT_99']) 
+        if isinstance(self.tags, string_types + integer_types):
+        # allow calls like TaggedDocument(words=words,tags='SENT_99') or TaggedDocument(words=words,tags=1), as a shorthand for TaggedDocument(words=words,tags=['SENT_99']) or TaggedDocument(words=words,tags=['1']).
             self.tags = [self.tags]
-        elif isinstance(self.tags, integer_types):
-        # allow calls like TaggedDocument(words=words,tags=1), as a shorthand for TaggedDocument(words=words,tags=['1']) 
-            self.tags = [str(self.tags)]
         return '%s(%s, %s)' % (self.__class__.__name__, self.words, self.tags)
 
 

--- a/gensim/test/test_doc2vec.py
+++ b/gensim/test/test_doc2vec.py
@@ -256,6 +256,13 @@ class TestDoc2VecModel(unittest.TestCase):
         expected_length = len(sentences) + len(model.docvecs.doctags)  # 9 sentences, 7 unique first tokens
         self.assertEquals(len(model.docvecs.doctag_syn0), expected_length)
 
+    def test_int_str_tag_types(self):
+        """Test int/str doc2vec tag."""
+        int_tag_corpus = [doc2vec.TaggedDocument(words, i) for i, words in enumerate(raw_sentences)]
+        str_tag_corpus = [doc2vec.TaggedDocument(words, str(i)) for i, words in enumerate(raw_sentences)]
+        self.assertEquals(int_tag_corpus, sentences)
+        self.assertEquals(str_tag_corpus, sentences)
+
     def models_equal(self, model, model2):
         # check words/hidden-weights
         self.assertEqual(len(model.vocab), len(model2.vocab))


### PR DESCRIPTION
Allow calls like TaggedDocument(words=words,tags='SENT_99'), as a shorthand for TaggedDocument(words=words,tags=['SENT_99']) 
