### PR TITLE
[MRG] ENH: Raise warnings if vocab in single character elements in word2vec/doc2vec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,6 @@ before_install:
 install:
   - conda create --yes -n gensim-test python=$TRAVIS_PYTHON_VERSION pip atlas numpy scipy
   - source activate gensim-test
+  - pip install testfixtures
   - python setup.py install
 script: python setup.py test

--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -645,8 +645,14 @@ class Doc2Vec(Word2Vec):
         min_reduce = 1
         interval_start = default_timer() - 0.00001  # guard against next sample being identical
         interval_count = 0
+        checked_string_types = 0
         vocab = defaultdict(int)
         for document_no, document in enumerate(documents):
+            if not checked_string_types:
+                if isinstance(document.words, string_types):
+                    logger.warn("Each 'words' should be a list of words (usually unicode strings)."
+                                "First 'words' here is instead plain %s." % type(document.words))
+                checked_string_types += 1
             if document_no % progress_per == 0:
                 interval_rate = (total_words - interval_count) / (default_timer() - interval_start)
                 logger.info("PROGRESS: at example #%i, processed %i words (%i/s), %i word types, %i tags",

--- a/gensim/test/test_doc2vec.py
+++ b/gensim/test/test_doc2vec.py
@@ -17,6 +17,7 @@ import tempfile
 
 from six.moves import zip as izip
 from collections import namedtuple
+from testfixtures import log_capture
 
 import numpy as np
 
@@ -279,6 +280,32 @@ class TestDoc2VecModel(unittest.TestCase):
         self.assertEqual(len(model.docvecs.offset2doctag), len(model2.docvecs.offset2doctag))
         self.assertTrue(np.allclose(model.docvecs.doctag_syn0, model2.docvecs.doctag_syn0))
 
+    @log_capture()
+    def testBuildVocabWarning(self, l):
+        """Test if logger warning is raised on non-ideal input to a doc2vec model"""
+        raw_sentences = ['human', 'machine']
+        sentences = [doc2vec.TaggedDocument(words, [i]) for i, words in enumerate(raw_sentences)]
+        model = doc2vec.Doc2Vec()
+        model.build_vocab(sentences)
+        warning = "Each 'words' should be a list of words (usually unicode strings)."
+        self.assertTrue(warning in str(l))
+
+    @log_capture()
+    def testTrainWarning(self, l):
+        """Test if warning is raised if alpha rises during subsequent calls to train()"""
+        raw_sentences = [['human'],
+                         ['graph', 'trees']]
+        sentences = [doc2vec.TaggedDocument(words, [i]) for i, words in enumerate(raw_sentences)]
+        model = doc2vec.Doc2Vec(alpha=0.025, min_alpha=0.025, min_count=1, workers=8, size=5)
+        model.build_vocab(sentences)
+        for epoch in range(10):
+            model.train(sentences)
+            model.alpha -= 0.002
+            model.min_alpha = model.alpha
+            if epoch == 5:
+                model.alpha += 0.05
+        warning = "Effective 'alpha' higher than previous training cycles"
+        self.assertTrue(warning in str(l))
 #endclass TestDoc2VecModel
 
 


### PR DESCRIPTION
Addresses #692. TODO:

- [X]  Raise warning if alpha is raised again after descending to minimum value. (Where should this be ideally done @gojomo?)
- [ ] Raise warning if calling `load()` on an instance rather than the class.
- [ ] Raise warning if mismatch in expected count for `train()` and actual.
- [X] Add test suit to test_doc2vec.py, test_word2vec.py

@tmylk @gojomo am I going on the right track with this? Also how should the warnings be dealt with in `doc2vec_inner.c`?