### PR TITLE
Added *_out.txt to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ data
 *.old
 *.model
 *~
+*_out.txt


### PR DESCRIPTION
This is to eliminate tracking files such as `sample_word2vec_out.txt` which are generated during nosetests.