### PR TITLE
Added function to filter 'n' most frequent words

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,7 @@ Changes
 * Add `similar_by_word()` and `similar_by_vector()` to word2vec (@isohyt, #381)
 * Convenience method for similarity of two out of training sentences to doc2vec (@ellolo, #707)
 * Dynamic Topic Modelling Tutorial updated with Dynamic Influence Model (@bhargavvader, #689)
+* Added function to filter 'n' most frequent words from the dictionary (@abhinavchawla, #718)
 
 0.12.4, 29/01/2016
 * Better internal handling of job batching in word2vec (#535)

--- a/gensim/corpora/dictionary.py
+++ b/gensim/corpora/dictionary.py
@@ -206,9 +206,9 @@ class Dictionary(utils.SaveLoad, Mapping):
         self.filter_tokens(good_ids=good_ids)
         logger.info("resulting dictionary: %s" % self)
 
-    def filter_n_most_frequent(self, keep_n):
+    def filter_n_most_frequent(self, remove_n):
         """
-        Filter out the 'keep_n' most frequent tokens that appear in the documents.
+        Filter out the 'remove_n' most frequent tokens that appear in the documents.
 
         After the pruning, shrink resulting gaps in word ids.
 
@@ -219,7 +219,7 @@ class Dictionary(utils.SaveLoad, Mapping):
         # determine which tokens to keep
         most_frequent_ids = (v for v in itervalues(self.token2id))
         most_frequent_ids = sorted(most_frequent_ids, key=self.dfs.get, reverse=True)
-        most_frequent_ids = most_frequent_ids[:keep_n]
+        most_frequent_ids = most_frequent_ids[:remove_n]
         # do the actual filtering, then rebuild dictionary to remove gaps in ids
         most_frequent_words = [(self[id], self.dfs.get(id, 0)) for id in most_frequent_ids]
         logger.info("discarding %i tokens: %s...",len(most_frequent_ids), most_frequent_words[:10])

--- a/gensim/corpora/dictionary.py
+++ b/gensim/corpora/dictionary.py
@@ -206,6 +206,27 @@ class Dictionary(utils.SaveLoad, Mapping):
         self.filter_tokens(good_ids=good_ids)
         logger.info("resulting dictionary: %s" % self)
 
+    def filter_n_most_frequent(self, keep_n):
+        """
+        Filter out the 'keep_n' most frequent tokens that appear in the documents.
+
+        After the pruning, shrink resulting gaps in word ids.
+
+        **Note**: Due to the gap shrinking, the same word may have a different
+        word id before and after the call to this function!
+        """
+
+        # determine which tokens to keep
+        most_frequent_ids = (v for v in itervalues(self.token2id))
+        most_frequent_ids = sorted(most_frequent_ids, key=self.dfs.get, reverse=True)
+        good_ids = good_ids[:keep_n]
+        # do the actual filtering, then rebuild dictionary to remove gaps in ids
+        most_frequent_words = [(self[id], self.dfs.get(id, 0)) for id in most_frequent_ids]
+        logger.info("discarding %i tokens: %s...",len(most_frequent_ids), most_frequent_words[:10])
+        
+        self.filter_tokens(bad_ids=most_frequent_ids)
+        logger.info("resulting dictionary: %s" % self)
+
     def filter_tokens(self, bad_ids=None, good_ids=None):
         """
         Remove the selected `bad_ids` tokens from all dictionary mappings, or, keep

--- a/gensim/corpora/dictionary.py
+++ b/gensim/corpora/dictionary.py
@@ -219,7 +219,7 @@ class Dictionary(utils.SaveLoad, Mapping):
         # determine which tokens to keep
         most_frequent_ids = (v for v in itervalues(self.token2id))
         most_frequent_ids = sorted(most_frequent_ids, key=self.dfs.get, reverse=True)
-        good_ids = good_ids[:keep_n]
+        most_frequent_ids = most_frequent_ids[:keep_n]
         # do the actual filtering, then rebuild dictionary to remove gaps in ids
         most_frequent_words = [(self[id], self.dfs.get(id, 0)) for id in most_frequent_ids]
         logger.info("discarding %i tokens: %s...",len(most_frequent_ids), most_frequent_words[:10])

--- a/gensim/test/test_corpora_dictionary.py
+++ b/gensim/test/test_corpora_dictionary.py
@@ -121,6 +121,13 @@ class TestDictionary(unittest.TestCase):
         expected = {0: 3, 1: 3, 2: 3, 3: 3}
         self.assertEqual(d.dfs, expected)
 
+    def testFilterMostFrequent(self):
+    	d = Dictionary(self.texts)
+    	d.filter_n_most_frequent(4)
+    	expected = {0: 2, 1: 2, 2: 2, 3: 2, 4: 2, 5: 2, 6: 2, 7: 2}
+    	self.assertEqual(d.dfs, expected)
+    	
+    	
     def testFilterTokens(self):
         self.maxDiff = 10000
         d = Dictionary(self.texts)


### PR DESCRIPTION
I realized that in filter_extremes function, they keep the 'n' most frequent word as provided in argument. I was asked by my professor to remove the 50 most frequent words in the dictionary and hence had to write my own code. 
Therefore I have added a function which will filter out the 'n' most frequent words.