### PR TITLE
Callbacks for LDAMultiCore

### DIFF
--- a/gensim/models/ensemblelda.py
+++ b/gensim/models/ensemblelda.py
@@ -687,7 +687,7 @@ class EnsembleLda(SaveLoad):
                 "`corpus` keyword argument."
             )
 
-        if type(topic_model_class) == type and issubclass(topic_model_class, ldamodel.LdaModel):
+        if type(topic_model_class) == type and issubclass(topic_model_class, ldamodel.LdaModel):  # noqa
             self.topic_model_class = topic_model_class
         else:
             kinds = {

--- a/gensim/models/ldamulticore.py
+++ b/gensim/models/ldamulticore.py
@@ -322,7 +322,7 @@ class LdaMulticore(LdaModel):
                         process_result_queue()
 
                 process_result_queue()
-                
+
             # append current epoch's metric values
             if self.callbacks:
                 current_metrics = callback.on_epoch_end(pass_)

--- a/gensim/test/test_word2vec.py
+++ b/gensim/test/test_word2vec.py
@@ -173,7 +173,7 @@ class TestWord2VecModel(unittest.TestCase):
     def test_online_learning_from_file(self):
         """Test that the algorithm is able to add new words to the
         vocabulary and to a trained model when using a sorted vocabulary"""
-        with temporary_file(get_tmpfile('gensim_word2vec1.tst')) as corpus_file,\
+        with temporary_file(get_tmpfile('gensim_word2vec1.tst')) as corpus_file, \
                 temporary_file(get_tmpfile('gensim_word2vec2.tst')) as new_corpus_file:
             utils.save_as_line_sentence(sentences, corpus_file)
             utils.save_as_line_sentence(new_sentences, new_corpus_file)
@@ -198,7 +198,7 @@ class TestWord2VecModel(unittest.TestCase):
     def test_online_learning_after_save_from_file(self):
         """Test that the algorithm is able to add new words to the
         vocabulary and to a trained model when using a sorted vocabulary"""
-        with temporary_file(get_tmpfile('gensim_word2vec1.tst')) as corpus_file,\
+        with temporary_file(get_tmpfile('gensim_word2vec1.tst')) as corpus_file, \
                 temporary_file(get_tmpfile('gensim_word2vec2.tst')) as new_corpus_file:
             utils.save_as_line_sentence(sentences, corpus_file)
             utils.save_as_line_sentence(new_sentences, new_corpus_file)


### PR DESCRIPTION
This PR upgrades the multi-core implementation of `LDA` to use callbacks 💪.

Callbacks are critical for model evaluation in general, and [have been requested in past](https://gensim.narkive.com/CGUSGGU5/11838-how-to-display-callbacks-training-progress-using-ldamulticore) for Gensim's model in particular 🙏. 

A usage example on News20 dataset:

```python
from gensim.models import LdaMulticore
from gensim.models.callbacks import CoherenceMetric, PerplexityMetric
from gensim.models import LdaMulticore, LdaModel

callback1 = CoherenceMetric(corpus=mm_corpus, dictionary=dictionary, coherence='u_mass', title='u_mass')
callback2 = CoherenceMetric(corpus=mm_corpus, texts=docs_tokenized, dictionary=dictionary, coherence='c_v', title='c_v',)
lda = LdaMulticore(mm_corpus, id2word=dictionary, num_topics=20, passes=20, batch=False, callbacks=[callback1,callback2])

# evaluation

import pandas as pd
import seaborn as sns
import matplotlib.pyplot as plt

metrics = pd.DataFrame(lda.metrics)
metrics.reset_index(names=['epoch'], inplace=True)
metrics['epoch'] = metrics['epoch']+1

fig,ax1 = plt.subplots()
ln1=ax1.plot(metrics['epoch'],metrics['u_mass'],label='$U_{mass}$',color='tab:red')
ax1.set_xlabel('epoch')
ax1.set_ylabel('$U_{mass}$')
ax2 = ax1.twinx()
ln2 = ax2.plot(metrics['epoch'],metrics['c_v'],label='$C_v$',color='tab:blue')
ax2.set_ylabel('$C_v$')
lines = ln1+ln2
labels = [l.get_label() for l in lines]
ax2.legend(lines, labels, loc=0)
plt.show()
```
This illustrates the point of using callbacks: we know how many epochs are sufficient to converge 🆒 
![image](https://github.com/RaRe-Technologies/gensim/assets/31315784/2f5cab86-e748-4a0f-b8fe-2c7bfa4f1c1a)

Also, the doc string has been made more accurate:
```python
        callbacks : list of :class:`~gensim.models.callbacks.Callback`
            Metric callbacks to log evaluation metrics of the model at every training epoch.
```

For a full example see [this Kaggle notebook](https://www.kaggle.com/code/mskorski/tracking-lda-topics-performance).

DISCLAIMER: this is a byproduct of the implementation for the purpose of a research paper.
