### PR TITLE
Handle optional parameters without implicit bool cast

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,3 +177,4 @@ BibTeX entry:
   [OpenBLAS]: https://xianyi.github.io/OpenBLAS/
   [source tar.gz]: https://pypi.org/project/gensim/
   [documentation]: https://radimrehurek.com/gensim/#install
+

--- a/gensim/models/tfidfmodel.py
+++ b/gensim/models/tfidfmodel.py
@@ -360,16 +360,16 @@ class TfidfModel(interfaces.TransformationABC):
         self.pivot = pivot
         self.eps = 1e-12
 
-        if smartirs:
+        if smartirs is not None:
             n_tf, n_df, n_n = self.smartirs
             self.wlocal = partial(smartirs_wlocal, local_scheme=n_tf)
             self.wglobal = partial(smartirs_wglobal, global_scheme=n_df)
 
-        if dictionary:
+        if dictionary is not None:
             # user supplied a Dictionary object, which already contains all the
             # statistics we need to construct the IDF mapping. we can skip the
             # step that goes through the corpus (= an optimization).
-            if corpus:
+            if corpus is not None:
                 logger.warning(
                     "constructor received both corpus and explicit inverse document frequencies; ignoring the corpus"
                 )
@@ -378,9 +378,9 @@ class TfidfModel(interfaces.TransformationABC):
             self.dfs = dictionary.dfs.copy()
             self.term_lens = {termid: len(term) for termid, term in dictionary.items()}
             self.idfs = precompute_idfs(self.wglobal, self.dfs, self.num_docs)
-            if not id2word:
+            if id2word is None:
                 self.id2word = dictionary
-        elif corpus:
+        elif corpus is not None:
             self.initialize(corpus)
         else:
             # NOTE: everything is left uninitialized; presumably the model will
@@ -388,7 +388,7 @@ class TfidfModel(interfaces.TransformationABC):
             pass
 
         # If smartirs is not None, override pivot and normalize
-        if not smartirs:
+        if smartirs is None:
             return
         if self.pivot is not None:
             if n_n in 'ub':


### PR DESCRIPTION
This PR updates the code in tfidfmodel.py that used "if [param]" to check if param had been defined. This method used an implicit casting to boolean to treat None as False, however that posed a few issues.

Mainly when using Pandas Series, which have a particular way of handling boolean casting (raises a warning prompting to use a defined method), despite the fact that they are proper Iterable Objects and should be allowed as parameters.

Other parts of the library already use "if [param] is not None", I just aligned the code to those parts.

Proper unit testing has been run to ensure this is not a breaking change.