### PR TITLE
Import deprecated scipy.linalg.triu from numpy.triu instead

### DIFF
--- a/gensim/matutils.py
+++ b/gensim/matutils.py
@@ -20,6 +20,10 @@ from scipy.stats import entropy
 from scipy.linalg import get_blas_funcs
 from scipy.linalg.lapack import get_lapack_funcs
 from scipy.special import psi  # gamma function utils
+try:
+    from numpy import triu
+except ImportError:
+    from scipy.linalg import triu
 
 
 logger = logging.getLogger(__name__)
@@ -1127,7 +1131,7 @@ def qr_destroy(la):
     qr, tau, work, info = geqrf(a, lwork=work[0], overwrite_a=True)
     del a  # free up mem
     assert info >= 0
-    r = np.triu(qr[:n, :n])
+    r = triu(qr[:n, :n])
     if m < n:  # rare case, #features < #topics
         qr = qr[:, :m]  # retains fortran order
     gorgqr, = get_lapack_funcs(('orgqr',), (qr,))


### PR DESCRIPTION
The scipy package latest released has removed the triu function due to its support already provided in numpy package 

Diff from the scipy library :
https://github.com/scipy/scipy/commit/5721702ee1471bdcbde0b33b850d91a9b4727d23#diff-6482beada610f60c724811cf77561f2bde8fd44ed2349939e505d28746a6d078


Removing the triu import from scipy library and getting it instead from numpy 

Fixes #3525.