### PR TITLE
Correct file argument name in KeyedVectors.save docstring

### DIFF
--- a/gensim/models/keyedvectors.py
+++ b/gensim/models/keyedvectors.py
@@ -762,7 +762,7 @@ class KeyedVectors(utils.SaveLoad):
 
         Parameters
         ----------
-        fname : str
+        fname_or_handle : str
             Path to the output file.
 
         See Also


### PR DESCRIPTION
Fixes issue : [https://github.com/piskvorky/gensim/issues/3528](https://github.com/piskvorky/gensim/issues/3528) 

Just a documentation update for filename argument for KeyedVectors.save() . The argument wasn't updated in the docs when it was changed in the parent class utils.SaveLoad from fname to fname_or_handle . Tested with code:

```
from gensim.models import KeyedVectors

# Create a KeyedVectors object
model = KeyedVectors(100)

# Attempt to save the model using the incorrect parameter name
try:
    model.save(fname_or_handle="my_model.kv")  ### fname gives error
except TypeError as e:
    print(e)
```