### PR TITLE
test numpy==2.0.0rc2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -325,7 +325,7 @@ docs_testenv = core_testenv + distributed_env + visdom_req + [
     'pandas',
 ]
 
-NUMPY_STR = 'numpy >= 1.18.5'
+NUMPY_STR = 'numpy == 2.0.0rc2'
 
 install_requires = [
     NUMPY_STR,
@@ -335,7 +335,7 @@ install_requires = [
 
 setup(
     name='gensim',
-    version='4.3.2.dev0',
+    version='4.3.2.np2test0',
     description='Python framework for fast Vector Space Modelling',
     long_description=LONG_DESCRIPTION,
 


### PR DESCRIPTION
Test what happens to our builds if `numpy==2.0.0rc2` is specified, as [Numpy 2.0 release is expected on June 16](https://numpy.org/news/#numpy-20-release-date-june-16) and there may be breaking changes that torpedo our current `numpy >= 1.18.5` dependency.