### PR TITLE
removed scipy from build-only dependencies

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -43,7 +43,7 @@ jobs:
           CIBW_ARCHS_WINDOWS: AMD64 x86
           CIBW_SKIP: pp* cp36-* cp37-* *-win32 *_i686 *-musllinux_*
           CIBW_TEST_COMMAND: pytest -rfxEXs --durations=20 --disable-warnings --showlocals --pyargs gensim
-          CIBW_TEST_REQUIRES: pytest testfixtures mock scipy<=1.13.1
+          CIBW_TEST_REQUIRES: pytest testfixtures mock scipy==1.13.1
           CIBW_TEST_SKIP: cp38* cp39* cp310* cp311* *_aarch64 *_arm64 *_universal2
           CIBW_BUILD_VERBOSITY: 3
 

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-latest]
+        os: [ubuntu-20.04, windows-2019, macos-12]
     steps:
 
       - name: Checkout
@@ -61,11 +61,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {python: '3.8', os: macos-latest}
-          - {python: '3.9', os: macos-latest}
-          - {python: '3.10', os: macos-latest}
-          - {python: '3.11', os: macos-latest}
-          - {python: '3.12', os: macos-latest}
+          - {python: '3.8', os: macos-12}
+          - {python: '3.9', os: macos-12}
+          - {python: '3.10', os: macos-12}
+          - {python: '3.11', os: macos-12}
+          - {python: '3.12', os: macos-12}
 
           - {python: '3.8', os: ubuntu-20.04}
           - {python: '3.9', os: ubuntu-20.04}

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -43,7 +43,7 @@ jobs:
           CIBW_ARCHS_WINDOWS: AMD64 x86
           CIBW_SKIP: pp* cp36-* cp37-* *-win32 *_i686 *-musllinux_*
           CIBW_TEST_COMMAND: pytest -rfxEXs --durations=20 --disable-warnings --showlocals --pyargs gensim
-          CIBW_TEST_REQUIRES: pytest testfixtures mock
+          CIBW_TEST_REQUIRES: pytest testfixtures mock scipy<=1.13.1
           CIBW_TEST_SKIP: cp38* cp39* cp310* cp311* *_aarch64 *_arm64 *_universal2
           CIBW_BUILD_VERBOSITY: 3
 

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -43,7 +43,7 @@ jobs:
           CIBW_ARCHS_WINDOWS: AMD64 x86
           CIBW_SKIP: pp* cp36-* cp37-* *-win32 *_i686 *-musllinux_*
           CIBW_TEST_COMMAND: pytest -rfxEXs --durations=20 --disable-warnings --showlocals --pyargs gensim
-          CIBW_TEST_REQUIRES: pytest testfixtures mock scipy==1.13.1
+          CIBW_TEST_REQUIRES: pytest testfixtures mock
           CIBW_TEST_SKIP: cp38* cp39* cp310* cp311* *_aarch64 *_arm64 *_universal2
           CIBW_BUILD_VERBOSITY: 3
 

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -61,11 +61,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {python: '3.8', os: macos-11}
-          - {python: '3.9', os: macos-11}
-          - {python: '3.10', os: macos-11}
-          - {python: '3.11', os: macos-11}
-          - {python: '3.12', os: macos-11}
+          - {python: '3.8', os: macos-latest}
+          - {python: '3.9', os: macos-latest}
+          - {python: '3.10', os: macos-latest}
+          - {python: '3.11', os: macos-latest}
+          - {python: '3.12', os: macos-latest}
 
           - {python: '3.8', os: ubuntu-20.04}
           - {python: '3.9', os: ubuntu-20.04}

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-11]
+        os: [ubuntu-20.04, windows-2019, macos-latest]
     steps:
 
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -50,12 +50,11 @@ Installation
 ------------
 
 This software depends on [NumPy], a Python package for
-scientific computing. You must have it installed prior to installing
-gensim.
-
-It is also recommended you install a fast BLAS library before installing
-NumPy. This is optional, but using an optimized BLAS such as MKL, [ATLAS] or
-[OpenBLAS] is known to improve performance by as much as an order of
+scientific computing. Please bear in mind that building NumPy from source
+(e.g. by installing gensim on a platform which lacks NumPy .whl distribution)
+is a non-trivial task involving [linking NumPy to a BLAS library].  
+It is recommended to provide a fast one (such as MKL, [ATLAS] or
+[OpenBLAS]) which can improve performance by as much as an order of
 magnitude. On OSX, NumPy picks up its vecLib BLAS automatically,
 so you don’t need to do anything special.
 
@@ -175,6 +174,7 @@ BibTeX entry:
   [Vector Space Model]: https://en.wikipedia.org/wiki/Vector_space_model
   [unsupervised document analysis]: https://en.wikipedia.org/wiki/Latent_semantic_indexing
   [NumPy]: https://numpy.org/install/
+  [linking NumPy to a BLAS library]: https://numpy.org/devdocs/building/blas_lapack.html
   [ATLAS]: https://math-atlas.sourceforge.net/
   [OpenBLAS]: https://xianyi.github.io/OpenBLAS/
   [source tar.gz]: https://pypi.org/project/gensim/

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ on Wikipedia.
 Installation
 ------------
 
-This software depends on [NumPy and Scipy], two Python packages for
-scientific computing. You must have them installed prior to installing
+This software depends on [NumPy], a Python package for
+scientific computing. You must have it installed prior to installing
 gensim.
 
 It is also recommended you install a fast BLAS library before installing
@@ -69,7 +69,9 @@ Or, if you have instead downloaded and unzipped the [source tar.gz]
 package:
 
 ```bash
-    python setup.py install
+    tar -xvzf gensim-X.X.X.tar.gz
+    cd gensim-X.X.X/
+    pip install .
 ```
 
 For alternative modes of installation, see the [documentation].
@@ -172,7 +174,7 @@ BibTeX entry:
   [documentation and Jupyter Notebook tutorials]: https://github.com/RaRe-Technologies/gensim/#documentation
   [Vector Space Model]: https://en.wikipedia.org/wiki/Vector_space_model
   [unsupervised document analysis]: https://en.wikipedia.org/wiki/Latent_semantic_indexing
-  [NumPy and Scipy]: https://scipy.org/install/
+  [NumPy]: https://numpy.org/install/
   [ATLAS]: https://math-atlas.sourceforge.net/
   [OpenBLAS]: https://xianyi.github.io/OpenBLAS/
   [source tar.gz]: https://pypi.org/project/gensim/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ requires = [
     # is 1.18.5, remove the line when they increase oldest supported Numpy for this platform
     "numpy==1.18.5; python_version=='3.8' and platform_machine not in 'arm64|aarch64'",
     "oldest-supported-numpy; python_version>'3.8' or platform_machine in 'arm64|aarch64'",
-    "scipy",
     "setuptools",
     "wheel",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,9 @@ requires = [
     # order of magnitude slower, so avoid it for now.
     #
     "Cython>=0.29.32,<3.0.0",
-    # oldest supported Numpy for non-'arm64|aarch64' architectures is 1.17.*
-    # as well as for 'Windows' on arm64. The oldest supported Numpy by Gensim
-    # is 1.18.5. Remove below line when they increase the oldest supported Numpy for those platforms
-    "numpy==1.18.5; python_version=='3.8' and platform_machine != 'aarch64' and (platform_machine != 'arm64' or platform_system == 'Windows')",
+    # oldest supported Numpy for this platform is 1.17 but the oldest supported by Gensim
+    # is 1.18.5, remove the line when they increase oldest supported Numpy for this platform
+    "numpy==1.18.5; python_version=='3.8' and platform_machine not in 'arm64|aarch64'",
     "oldest-supported-numpy; python_version>'3.8' or platform_machine in 'arm64|aarch64'",
     "setuptools",
     "wheel",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,10 @@ requires = [
     # order of magnitude slower, so avoid it for now.
     #
     "Cython>=0.29.32,<3.0.0",
-    # oldest supported Numpy for this platform is 1.17 but the oldest supported by Gensim
-    # is 1.18.5, remove the line when they increase oldest supported Numpy for this platform
-    "numpy==1.18.5; python_version=='3.8' and platform_machine not in 'arm64|aarch64'",
+    # oldest supported Numpy for non-'arm64|aarch64' architectures is 1.17.*
+    # as well as for 'Windows' on arm64. The oldest supported Numpy by Gensim
+    # is 1.18.5. Remove below line when they increase the oldest supported Numpy for those platforms
+    "numpy==1.18.5; python_version=='3.8' and platform_machine != 'aarch64' and (platform_machine != 'arm64' or platform_system == 'Windows')",
     "oldest-supported-numpy; python_version>'3.8' or platform_machine in 'arm64|aarch64'",
     "setuptools",
     "wheel",

--- a/setup.py
+++ b/setup.py
@@ -331,7 +331,10 @@ NUMPY_STR = 'numpy >= 1.18.5, < 2.0'
 
 install_requires = [
     NUMPY_STR,
-    'scipy >= 1.7.0',
+    #
+    # scipy 1.14.0 and onwards removes deprecated sparsetools submodule
+    #
+    'scipy >= 1.7.0, <1.14.0',
     'smart_open >= 1.8.1',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -324,7 +324,10 @@ docs_testenv = core_testenv + distributed_env + visdom_req + [
     'pandas',
 ]
 
-NUMPY_STR = 'numpy >= 1.18.5'
+#
+# see https://github.com/piskvorky/gensim/pull/3535
+#
+NUMPY_STR = 'numpy >= 1.18.5, < 2.0'
 
 install_requires = [
     NUMPY_STR,


### PR DESCRIPTION
Resolves: https://github.com/piskvorky/gensim/issues/3536

In addition to removing scipy from _build-system.requires_ table I've also updated the README file. 

Please refer to the comments for some additional doubts I have regarding more changes that might need to be introduced. 