### PR TITLE
Chiheb ia scipy patch 1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires = [
     # is 1.18.5, remove the line when they increase oldest supported Numpy for this platform
     "numpy==1.18.5; python_version=='3.8' and platform_machine not in 'arm64|aarch64'",
     "oldest-supported-numpy; python_version>'3.8' or platform_machine in 'arm64|aarch64'",
-    "scipy",
+    "scipy>=1.7.0,<1.12.0",
     "setuptools",
     "wheel",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires = [
     # is 1.18.5, remove the line when they increase oldest supported Numpy for this platform
     "numpy==1.18.5; python_version=='3.8' and platform_machine not in 'arm64|aarch64'",
     "oldest-supported-numpy; python_version>'3.8' or platform_machine in 'arm64|aarch64'",
-    "scipy>=1.7.0,<1.12.0",
+    "scipy>=1.7.0,<=1.12.0",
     "setuptools",
     "wheel",
 ]

--- a/setup.py
+++ b/setup.py
@@ -331,7 +331,7 @@ NUMPY_STR = 'numpy >= 1.18.5, < 2.0'
 
 install_requires = [
     NUMPY_STR,
-    'scipy >= 1.7.0',
+    'scipy>=1.7.0,<=1.12.0',
     'smart_open >= 1.8.1',
 ]
 


### PR DESCRIPTION
The scipy functions tri, triu & tril have been removed from scipy 1.12 and later versions as per 
https://docs.scipy.org/doc/scipy/release/1.11.0-notes.html#deprecated-features