### PR TITLE
Pin scipy in installation requirements as well to fix failing tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -331,7 +331,7 @@ NUMPY_STR = 'numpy >= 1.18.5, < 2.0'
 
 install_requires = [
     NUMPY_STR,
-    'scipy >= 1.7.0',
+    'scipy >= 1.7.0, <= 1.13.1',
     'smart_open >= 1.8.1',
 ]
 


### PR DESCRIPTION
@mpenkov I did some digging to try and understand why the tests started failing suddenly. The important difference is that the successful builds were running the tests against scipy==1.13.1. This is because the version isn't pinned inside setup.py.

This completes the version pinning of scipy started in afbb82ea3446b5462a6ae1f5b02d338ff0170e5a

The tests are currently failing because the build system runs the test against scipy==1.14.0 which doesn't have the required sparsetools (csc_matvecs, specifically) anymore. This commit makes sure that gensim also doesn't test against a version higher than 1.13.1.

Fixes #3544 
