### PR TITLE
Fix import triu

### DIFF
--- a/gensim/matutils.py
+++ b/gensim/matutils.py
@@ -20,10 +20,7 @@ from scipy.stats import entropy
 from scipy.linalg import get_blas_funcs
 from scipy.linalg.lapack import get_lapack_funcs
 from scipy.special import psi  # gamma function utils
-try:
-    from numpy import triu
-except ImportError:
-    from scipy.linalg import triu
+from scipy.sparse import triu
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
I'm using scipy 1.13.1 and it works in manual fix. I found scipy in the documentation starting with version 1.12.0, but it appeared in the source code much earlier. The triu function has been moved from scipy.linalg to scipy.sparse. I changed imports:
```
try:
    from numpy import triu
except ImportError:
    from scipy.linalg import triu
```
to `from scipy.sparse import triu` and it worked.