### PR TITLE
Sync PyPi package description with Github README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,21 +123,21 @@ Adopters
 
 | Company | Logo | Industry | Use of Gensim |
 |---------|------|----------|---------------|
-| [RARE Technologies](https://rare-technologies.com/) | ![rare](docs/src/readme_images/rare.png) | ML & NLP consulting | Creators of Gensim – this is us! |
-| [Amazon](http://www.amazon.com/) |  ![amazon](docs/src/readme_images/amazon.png) | Retail |  Document similarity. |
-| [National Institutes of Health](https://github.com/NIHOPA/pipeline_word2vec) | ![nih](docs/src/readme_images/nih.png) | Health | Processing grants and publications with word2vec. |
-| [Cisco Security](http://www.cisco.com/c/en/us/products/security/index.html) | ![cisco](docs/src/readme_images/cisco.png) | Security |  Large-scale fraud detection. |
-| [Mindseye](http://www.mindseyesolutions.com/) | ![mindseye](docs/src/readme_images/mindseye.png) | Legal | Similarities in legal documents. |
-| [Channel 4](http://www.channel4.com/) | ![channel4](docs/src/readme_images/channel4.png) | Media | Recommendation engine. |
-| [Talentpair](http://talentpair.com) | ![talent-pair](docs/src/readme_images/talent-pair.png) | HR | Candidate matching in high-touch recruiting. |
-| [Juju](http://www.juju.com/)  | ![juju](docs/src/readme_images/juju.png) | HR | Provide non-obvious related job suggestions. |
-| [Tailwind](https://www.tailwindapp.com/) | ![tailwind](docs/src/readme_images/tailwind.png) | Media | Post interesting and relevant content to Pinterest. |
-| [Issuu](https://issuu.com/) | ![issuu](docs/src/readme_images/issuu.png) | Media | Gensim's LDA module lies at the very core of the analysis we perform on each uploaded publication to figure out what it's all about. |
-| [Search Metrics](http://www.searchmetrics.com/) | ![search-metrics](docs/src/readme_images/search-metrics.png) | Content Marketing | Gensim word2vec used for entity disambiguation in Search Engine Optimisation. |
-| [12K Research](https://12k.com/) | ![12k](docs/src/readme_images/12k.png)| Media |   Document similarity analysis on media articles. |
-| [Stillwater Supercomputing](http://www.stillwater-sc.com/) | ![stillwater](docs/src/readme_images/stillwater.png) | Hardware | Document comprehension and association with word2vec. |
-| [SiteGround](https://www.siteground.com/) |  ![siteground](docs/src/readme_images/siteground.png) | Web hosting | An ensemble search engine which uses different embeddings models and similarities, including word2vec, WMD, and LDA. |
-| [Capital One](https://www.capitalone.com/) | ![capitalone](docs/src/readme_images/capitalone.png) | Finance | Topic modeling for customer complaints exploration. |
+| [RARE Technologies](https://rare-technologies.com/) | ![rare](https://raw.githubusercontent.com/piskvorky/gensim/develop/docs/src/readme_images/rare.png) | ML & NLP consulting | Creators of Gensim – this is us! |
+| [Amazon](http://www.amazon.com/) |  ![amazon](https://raw.githubusercontent.com/piskvorky/gensim/develop/docs/src/readme_images/amazon.png) | Retail |  Document similarity. |
+| [National Institutes of Health](https://github.com/NIHOPA/pipeline_word2vec) | ![nih](https://raw.githubusercontent.com/piskvorky/gensim/develop/docs/src/readme_images/nih.png) | Health | Processing grants and publications with word2vec. |
+| [Cisco Security](http://www.cisco.com/c/en/us/products/security/index.html) | ![cisco](https://raw.githubusercontent.com/piskvorky/gensim/develop/docs/src/readme_images/cisco.png) | Security |  Large-scale fraud detection. |
+| [Mindseye](http://www.mindseyesolutions.com/) | ![mindseye](https://raw.githubusercontent.com/piskvorky/gensim/develop/docs/src/readme_images/mindseye.png) | Legal | Similarities in legal documents. |
+| [Channel 4](http://www.channel4.com/) | ![channel4](https://raw.githubusercontent.com/piskvorky/gensim/develop/docs/src/readme_images/channel4.png) | Media | Recommendation engine. |
+| [Talentpair](http://talentpair.com) | ![talent-pair](https://raw.githubusercontent.com/piskvorky/gensim/develop/docs/src/readme_images/talent-pair.png) | HR | Candidate matching in high-touch recruiting. |
+| [Juju](http://www.juju.com/)  | ![juju](https://raw.githubusercontent.com/piskvorky/gensim/develop/docs/src/readme_images/juju.png) | HR | Provide non-obvious related job suggestions. |
+| [Tailwind](https://www.tailwindapp.com/) | ![tailwind](https://raw.githubusercontent.com/piskvorky/gensim/develop/docs/src/readme_images/tailwind.png) | Media | Post interesting and relevant content to Pinterest. |
+| [Issuu](https://issuu.com/) | ![issuu](https://raw.githubusercontent.com/piskvorky/gensim/develop/docs/src/readme_images/issuu.png) | Media | Gensim's LDA module lies at the very core of the analysis we perform on each uploaded publication to figure out what it's all about. |
+| [Search Metrics](http://www.searchmetrics.com/) | ![search-metrics](https://raw.githubusercontent.com/piskvorky/gensim/develop/docs/src/readme_images/search-metrics.png) | Content Marketing | Gensim word2vec used for entity disambiguation in Search Engine Optimisation. |
+| [12K Research](https://12k.com/) | ![12k](https://raw.githubusercontent.com/piskvorky/gensim/develop/docs/src/readme_images/12k.png)| Media |   Document similarity analysis on media articles. |
+| [Stillwater Supercomputing](http://www.stillwater-sc.com/) | ![stillwater](https://raw.githubusercontent.com/piskvorky/gensim/develop/docs/src/readme_images/stillwater.png) | Hardware | Document comprehension and association with word2vec. |
+| [SiteGround](https://www.siteground.com/) |  ![siteground](https://raw.githubusercontent.com/piskvorky/gensim/develop/docs/src/readme_images/siteground.png) | Web hosting | An ensemble search engine which uses different embeddings models and similarities, including word2vec, WMD, and LDA. |
+| [Capital One](https://www.capitalone.com/) | ![capitalone](https://raw.githubusercontent.com/piskvorky/gensim/develop/docs/src/readme_images/capitalone.png) | Finance | Topic modeling for customer complaints exploration. |
 
 -------
 
@@ -179,4 +179,3 @@ BibTeX entry:
   [OpenBLAS]: https://xianyi.github.io/OpenBLAS/
   [source tar.gz]: https://pypi.org/project/gensim/
   [documentation]: https://radimrehurek.com/gensim/#install
-

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ import platform
 import shutil
 import sys
 from collections import OrderedDict
+from pathlib import Path
 
 from setuptools import Extension, find_packages, setup, distutils
 from setuptools.command.build_ext import build_ext
@@ -158,112 +159,6 @@ if WHEELHOUSE_UPLOADER_COMMANDS.intersection(sys.argv):
     cmdclass.update(vars(wheelhouse_uploader.cmd))
 
 
-LONG_DESCRIPTION = u"""
-==============================================
-gensim -- Topic Modelling in Python
-==============================================
-
-|GA|_
-|Wheel|_
-
-.. |GA| image:: https://github.com/RaRe-Technologies/gensim/actions/workflows/tests.yml/badge.svg?branch=develop
-.. |Wheel| image:: https://img.shields.io/pypi/wheel/gensim.svg
-
-.. _GA: https://github.com/RaRe-Technologies/gensim/actions
-.. _Downloads: https://pypi.org/project/gensim/
-.. _License: https://radimrehurek.com/gensim/intro.html#licensing
-.. _Wheel: https://pypi.org/project/gensim/
-
-Gensim is a Python library for *topic modelling*, *document indexing* and *similarity retrieval* with large corpora.
-Target audience is the *natural language processing* (NLP) and *information retrieval* (IR) community.
-
-Features
----------
-
-* All algorithms are **memory-independent** w.r.t. the corpus size (can process input larger than RAM, streamed, out-of-core)
-* **Intuitive interfaces**
-
-  * easy to plug in your own input corpus/datastream (simple streaming API)
-  * easy to extend with other Vector Space algorithms (simple transformation API)
-
-* Efficient multicore implementations of popular algorithms, such as online **Latent Semantic Analysis (LSA/LSI/SVD)**,
-  **Latent Dirichlet Allocation (LDA)**, **Random Projections (RP)**, **Hierarchical Dirichlet Process (HDP)** or **word2vec deep learning**.
-* **Distributed computing**: can run *Latent Semantic Analysis* and *Latent Dirichlet Allocation* on a cluster of computers.
-* Extensive `documentation and Jupyter Notebook tutorials <https://github.com/RaRe-Technologies/gensim/#documentation>`_.
-
-
-If this feature list left you scratching your head, you can first read more about the `Vector
-Space Model <https://en.wikipedia.org/wiki/Vector_space_model>`_ and `unsupervised
-document analysis <https://en.wikipedia.org/wiki/Latent_semantic_indexing>`_ on Wikipedia.
-
-Installation
-------------
-
-This software depends on `NumPy and Scipy <https://scipy.org/install/>`_, two Python packages for scientific computing.
-You must have them installed prior to installing `gensim`.
-
-It is also recommended you install a fast BLAS library before installing NumPy. This is optional, but using an optimized BLAS such as MKL, `ATLAS <https://math-atlas.sourceforge.net/>`_ or `OpenBLAS <https://xianyi.github.io/OpenBLAS/>`_ is known to improve performance by as much as an order of magnitude. On OSX, NumPy picks up its vecLib BLAS automatically, so you don't need to do anything special.
-
-Install the latest version of gensim::
-
-    pip install --upgrade gensim
-
-Or, if you have instead downloaded and unzipped the `source tar.gz <https://pypi.org/project/gensim/>`_ package::
-
-    python setup.py install
-
-
-For alternative modes of installation, see the `documentation <https://radimrehurek.com/gensim/#install>`_.
-
-Gensim is being `continuously tested <https://radimrehurek.com/gensim/#testing>`_ under all `supported Python versions <https://github.com/RaRe-Technologies/gensim/wiki/Gensim-And-Compatibility>`_.
-Support for Python 2.7 was dropped in gensim 4.0.0 – install gensim 3.8.3 if you must use Python 2.7.
-
-
-How come gensim is so fast and memory efficient? Isn't it pure Python, and isn't Python slow and greedy?
---------------------------------------------------------------------------------------------------------
-
-Many scientific algorithms can be expressed in terms of large matrix operations (see the BLAS note above). Gensim taps into these low-level BLAS libraries, by means of its dependency on NumPy. So while gensim-the-top-level-code is pure Python, it actually executes highly optimized Fortran/C under the hood, including multithreading (if your BLAS is so configured).
-
-Memory-wise, gensim makes heavy use of Python's built-in generators and iterators for streamed data processing. Memory efficiency was one of gensim's `design goals <https://radimrehurek.com/gensim/intro.html#design-principles>`_, and is a central feature of gensim, rather than something bolted on as an afterthought.
-
-Documentation
--------------
-* `QuickStart`_
-* `Tutorials`_
-* `Tutorial Videos`_
-* `Official Documentation and Walkthrough`_
-
-Citing gensim
--------------
-
-When `citing gensim in academic papers and theses <https://scholar.google.cz/citations?view_op=view_citation&hl=en&user=9vG_kV0AAAAJ&citation_for_view=9vG_kV0AAAAJ:u-x6o8ySG0sC>`_, please use this BibTeX entry::
-
-  @inproceedings{rehurek_lrec,
-        title = {{Software Framework for Topic Modelling with Large Corpora}},
-        author = {Radim {\\v R}eh{\\r u}{\\v r}ek and Petr Sojka},
-        booktitle = {{Proceedings of the LREC 2010 Workshop on New
-             Challenges for NLP Frameworks}},
-        pages = {45--50},
-        year = 2010,
-        month = May,
-        day = 22,
-        publisher = {ELRA},
-        address = {Valletta, Malta},
-        language={English}
-  }
-
-----------------
-
-Gensim is open source software released under the `GNU LGPLv2.1 license <https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html>`_.
-Copyright (c) 2009-now Radim Rehurek
-
-.. _Official Documentation and Walkthrough: https://radimrehurek.com/gensim/
-.. _Tutorials: https://github.com/RaRe-Technologies/gensim/blob/develop/tutorials.md#tutorials
-.. _Tutorial Videos: https://github.com/RaRe-Technologies/gensim/blob/develop/tutorials.md#videos
-.. _QuickStart: https://radimrehurek.com/gensim/gensim_numfocus/auto_examples/core/run_core_concepts.html
-
-"""
-
 distributed_env = ['Pyro4 >= 4.27']
 
 visdom_req = ['visdom >= 0.1.8, != 0.1.8.7']
@@ -339,8 +234,8 @@ setup(
     name='gensim',
     version='4.3.2.dev0',
     description='Python framework for fast Vector Space Modelling',
-    long_description=LONG_DESCRIPTION,
-
+    long_description=Path("README.md").read_text(),
+    long_description_content_type='text/markdown',
     ext_modules=ext_modules,
     cmdclass=cmdclass,
     packages=find_packages(),


### PR DESCRIPTION
closes #3452 

The reason your [PyPi Project Page](https://pypi.org/project/gensim/) is out of sync is because of an out-dated hard-coded description in your setup.py file. To fix it:

* `setup.py` now uses the project README text for `long_description`
* All README image paths have been updated to their respective HTTP urls.