### PR TITLE
Numpy 2.0.0 update and removing deprecated scipy modules

### DIFF
--- a/gensim/models/lsimodel.py
+++ b/gensim/models/lsimodel.py
@@ -66,7 +66,6 @@ import time
 import numpy as np
 import scipy.linalg
 import scipy.sparse
-from scipy.sparse import sparsetools
 
 from gensim import interfaces, matutils, utils
 from gensim.models import basemodel
@@ -960,10 +959,8 @@ def stochastic_svd(
         m, n = corpus.shape
         assert num_terms == m, f"mismatch in number of features: {m} in sparse matrix vs. {num_terms} parameter"
         o = random_state.normal(0.0, 1.0, (n, samples)).astype(y.dtype)  # draw a random gaussian matrix
-        sparsetools.csc_matvecs(
-            m, n, samples, corpus.indptr, corpus.indices,
-            corpus.data, o.ravel(), y.ravel(),
-        )  # y = corpus * o
+        y = corpus.dot(o) # y = corpus * o
+
         del o
 
         # unlike np, scipy.sparse `astype()` copies everything, even if there is no change to dtype!
@@ -994,10 +991,7 @@ def stochastic_svd(
             num_docs += n
             logger.debug("multiplying chunk * gauss")
             o = random_state.normal(0.0, 1.0, (n, samples), ).astype(dtype)  # draw a random gaussian matrix
-            sparsetools.csc_matvecs(
-                m, n, samples, chunk.indptr, chunk.indices,  # y = y + chunk * o
-                chunk.data, o.ravel(), y.ravel(),
-            )
+            y = y + chunk * o
             del chunk, o
         y = [y]
         q, _ = matutils.qr_destroy(y)  # orthonormalize the range

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,10 @@ requires = [
     "Cython>=0.29.32,<3.0.0",
     # oldest supported Numpy for this platform is 1.17 but the oldest supported by Gensim
     # is 1.18.5, remove the line when they increase oldest supported Numpy for this platform
-    "numpy==1.18.5; python_version=='3.8' and platform_machine not in 'arm64|aarch64'",
-    "oldest-supported-numpy; python_version>'3.8' or platform_machine in 'arm64|aarch64'",
+    # 20240604 GM: testing numpy-2.0.0rc2 which requires python >= 3.9 (to 3.12)
+    "numpy==2.0.0rc2; python_version>='3.9' and platform_machine not in 'arm64|aarch64'",
+    # "oldest-supported-numpy; python_version>'3.8' or platform_machine in 'arm64|aarch64'",
+    "scipy",
     "setuptools",
     "wheel",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
     # oldest supported Numpy for this platform is 1.17 but the oldest supported by Gensim
     # is 1.18.5, remove the line when they increase oldest supported Numpy for this platform
     # 20240604 GM: testing numpy-2.0.0rc2 which requires python >= 3.9 (to 3.12)
-    "numpy==2.0.0rc2; python_version>='3.9' and platform_machine not in 'arm64|aarch64'",
+    "numpy==2.0.0; python_version>='3.9' and platform_machine not in 'arm64|aarch64'",
     # "oldest-supported-numpy; python_version>'3.8' or platform_machine in 'arm64|aarch64'",
     "scipy",
     "setuptools",

--- a/setup.py
+++ b/setup.py
@@ -337,7 +337,7 @@ install_requires = [
 
 setup(
     name='gensim',
-    version='4.3.2.np2test0',
+    version='4.4.0a0.dev0',
     description='Python framework for fast Vector Space Modelling',
     long_description=LONG_DESCRIPTION,
 

--- a/setup.py
+++ b/setup.py
@@ -324,10 +324,7 @@ docs_testenv = core_testenv + distributed_env + visdom_req + [
     'pandas',
 ]
 
-#
-# see https://github.com/piskvorky/gensim/pull/3535
-#
-NUMPY_STR = 'numpy >= 1.18.5, < 2.0'
+NUMPY_STR = 'numpy == 2.0.0rc2'
 
 install_requires = [
     NUMPY_STR,
@@ -340,7 +337,7 @@ install_requires = [
 
 setup(
     name='gensim',
-    version='4.3.3',
+    version='4.3.2.np2test0',
     description='Python framework for fast Vector Space Modelling',
     long_description=LONG_DESCRIPTION,
 


### PR DESCRIPTION
This PR is an initial attempt at porting the project to numpy 2.0.0 - so far running the tests manually after installing all dependencies seemed fine. I removed the deprecated scipy sparse functions and replaced them with the normal operator versions.