### PR TITLE
Migration numPy 2.0 and remove deprecated scipy sparsetools functions

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -25,7 +25,7 @@ jobs:
           #
           # We use Py3.8 here for historical reasons.
           #
-          python-version: "3.8"
+          python-version: "3.9"
 
       - name: Update pip
         run: python -m pip install -U pip
@@ -35,7 +35,7 @@ jobs:
           sudo apt-get -yq update
           sudo apt-get -yq remove texlive-binaries --purge
           sudo apt-get -yq --no-install-suggests --no-install-recommends --force-yes install dvipng texlive-latex-base texlive-latex-extra texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended latexmk
-          sudo apt-get -yq install build-essential python3.8-dev
+          sudo apt-get -yq install build-essential python3.9-dev
       - name: Install gensim and its dependencies
         run: pip install -e .[docs]
 

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -61,21 +61,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {python: '3.8', os: macos-12}
           - {python: '3.9', os: macos-12}
           - {python: '3.10', os: macos-12}
           - {python: '3.11', os: macos-12}
           - {python: '3.12', os: macos-12}
 
-          - {python: '3.8', os: ubuntu-20.04}
           - {python: '3.9', os: ubuntu-20.04}
           - {python: '3.10', os: ubuntu-20.04}
           - {python: '3.11', os: ubuntu-20.04}
           - {python: '3.12', os: ubuntu-20.04}
 
-          - {python: '3.8', os: windows-2019}
           - {python: '3.9', os: windows-2019}
-
           - {python: '3.10', os: windows-2019}
           - {python: '3.11', os: windows-2019}
           - {python: '3.12', os: windows-2019}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
           #
           # We use Py3.8 here for historical reasons.
           #
-          python-version: "3.8"
+          python-version: "3.9"
 
       - name: Update pip
         run: python -m pip install -U pip
@@ -43,7 +43,7 @@ jobs:
           sudo apt-get -yq update
           sudo apt-get -yq remove texlive-binaries --purge
           sudo apt-get -yq --no-install-suggests --no-install-recommends --force-yes install dvipng texlive-latex-base texlive-latex-extra texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended latexmk
-          sudo apt-get -yq install build-essential python3.8-dev
+          sudo apt-get -yq install build-essential python3.9-dev
       - name: Install gensim and its dependencies
         run: pip install -e .[docs]
 
@@ -63,13 +63,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {python: '3.8', os: ubuntu-20.04}
           - {python: '3.9', os: ubuntu-20.04}
           - {python: '3.10', os: ubuntu-20.04}
           - {python: '3.11', os: ubuntu-20.04}
           - {python: '3.12', os: ubuntu-20.04}
 
-          - {python: '3.8', os: windows-2019}
           - {python: '3.9', os: windows-2019}
           - {python: '3.10', os: windows-2019}
           - {python: '3.11', os: windows-2019}

--- a/gensim/models/keyedvectors.py
+++ b/gensim/models/keyedvectors.py
@@ -1977,7 +1977,7 @@ def _word2vec_read_text(fin, kv, counts, vocab_size, vector_size, datatype, unic
 
 def _word2vec_line_to_vector(line, datatype, unicode_errors, encoding):
     parts = utils.to_unicode(line.rstrip(), encoding=encoding, errors=unicode_errors).split(" ")
-    word, weights = parts[0], [datatype(x) for x in parts[1:]]
+    word, weights = parts[0], [datatype(x).item() for x in parts[1:]]
     return word, weights
 
 

--- a/gensim/models/keyedvectors.py
+++ b/gensim/models/keyedvectors.py
@@ -746,7 +746,9 @@ class KeyedVectors(utils.SaveLoad):
         """Sort the vocabulary so the most frequent words have the lowest indexes."""
         if not len(self):
             return  # noop if empty
-        count_sorted_indexes = np.argsort(self.expandos['count'])[::-1]
+        counts = np.asarray(self.expandos['count'], dtype=np.int64)
+        indices = np.arange(len(counts))
+        count_sorted_indexes = np.lexsort((-indices, -counts))
         self.index_to_key = [self.index_to_key[idx] for idx in count_sorted_indexes]
         self.allocate_vecattrs()
         for k in self.expandos:

--- a/gensim/models/keyedvectors.py
+++ b/gensim/models/keyedvectors.py
@@ -495,9 +495,9 @@ class KeyedVectors(utils.SaveLoad):
         if len(keys) == 0:
             raise ValueError("cannot compute mean with no input")
         if isinstance(weights, list):
-            weights = np.array(weights)
+            weights = np.array(weights, dtype=self.vectors.dtype)
         if weights is None:
-            weights = np.ones(len(keys))
+            weights = np.ones(len(keys), dtype=self.vectors.dtype)
         if len(keys) != weights.shape[0]:  # weights is a 1-D numpy array
             raise ValueError(
                 "keys and weights array must have same number of elements"

--- a/gensim/models/keyedvectors.py
+++ b/gensim/models/keyedvectors.py
@@ -1669,7 +1669,7 @@ class KeyedVectors(utils.SaveLoad):
                 if binary:
                     fout.write(f"{prefix}{key} ".encode('utf8') + key_vector.astype(REAL).tobytes())
                 else:
-                    fout.write(f"{prefix}{key} {' '.join(repr(val) for val in key_vector.tolist())}\n".encode('utf8'))
+                    fout.write(f"{prefix}{key} {' '.join(str(val) for val in key_vector)}\n".encode('utf8'))
 
     @classmethod
     def load_word2vec_format(

--- a/gensim/models/keyedvectors.py
+++ b/gensim/models/keyedvectors.py
@@ -1667,7 +1667,7 @@ class KeyedVectors(utils.SaveLoad):
                 if binary:
                     fout.write(f"{prefix}{key} ".encode('utf8') + key_vector.astype(REAL).tobytes())
                 else:
-                    fout.write(f"{prefix}{key} {' '.join(repr(val) for val in key_vector)}\n".encode('utf8'))
+                    fout.write(f"{prefix}{key} {' '.join(repr(val) for val in key_vector.tolist())}\n".encode('utf8'))
 
     @classmethod
     def load_word2vec_format(

--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -133,10 +133,11 @@ def update_dir_prior(prior, N, logphat, rho):
         The updated prior.
 
     """
+    dtype = logphat.dtype
     gradf = N * (psi(np.sum(prior)) - psi(prior) + logphat)
 
-    c = N * polygamma(1, np.sum(prior))
-    q = -N * polygamma(1, prior)
+    c = N * polygamma(1, np.sum(prior)).astype(dtype)
+    q = -N * polygamma(1, prior).astype(dtype)
 
     b = np.sum(gradf / q) / (1 / c + np.sum(1 / q))
 

--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -1082,7 +1082,7 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
             # only update if this isn't an additional pass
             self.num_updates += other.numdocs
 
-    def bound(self, corpus, gamma=None, subsample_ratio=1.0):
+    def bound(self, corpus, gamma=None, subsample_ratio=1.0) -> float:
         """Estimate the variational bound of documents from the corpus as E_q[log p(corpus)] - E_q[log q(corpus)].
 
         Parameters
@@ -1099,11 +1099,11 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
 
         Returns
         -------
-        numpy.ndarray
+        float
             The variational bound score calculated for each document.
 
         """
-        score = 0.0
+        score = np.float64(0.0)
         _lambda = self.state.get_lambda()
         Elogbeta = dirichlet_expectation(_lambda)
 

--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -111,33 +111,33 @@ from gensim.models.callbacks import Callback
 logger = logging.getLogger(__name__)
 
 
-def update_dir_prior(prior, N, logphat, rho):
+def update_dir_prior(prior: np.ndarray, N: float, logphat: np.ndarray, rho: float) -> np.ndarray:
     """Update a given prior using Newton's method, described in
     `J. Huang: "Maximum Likelihood Estimation of Dirichlet Distribution Parameters"
     <http://jonathan-huang.org/research/dirichlet/dirichlet.pdf>`_.
 
     Parameters
     ----------
-    prior : list of float
+    prior : ndarray
         The prior for each possible outcome at the previous iteration (to be updated).
-    N : int
+    N : float
         Number of observations.
-    logphat : list of float
+    logphat : ndarray
         Log probabilities for the current estimation, also called "observed sufficient statistics".
     rho : float
         Learning rate.
 
     Returns
     -------
-    list of float
+    ndarray
         The updated prior.
 
     """
-    dtype = logphat.dtype
+    dtype = prior.dtype
     gradf = N * (psi(np.sum(prior)) - psi(prior) + logphat)
 
-    c = N * polygamma(1, np.sum(prior)).astype(dtype)
-    q = -N * polygamma(1, prior).astype(dtype)
+    c = N * np.array(polygamma(1, np.sum(prior, dtype=dtype)), dtype=dtype)
+    q = -N * np.array(polygamma(1, prior), dtype=dtype)
 
     b = np.sum(gradf / q) / (1 / c + np.sum(1 / q))
 

--- a/gensim/models/lsimodel.py
+++ b/gensim/models/lsimodel.py
@@ -959,7 +959,7 @@ def stochastic_svd(
         m, n = corpus.shape
         assert num_terms == m, f"mismatch in number of features: {m} in sparse matrix vs. {num_terms} parameter"
         o = random_state.normal(0.0, 1.0, (n, samples)).astype(y.dtype)  # draw a random gaussian matrix
-        y = corpus.dot(o) # y = corpus * o
+        y = corpus.dot(o)  # y = corpus * o
 
         del o
 

--- a/gensim/models/lsimodel.py
+++ b/gensim/models/lsimodel.py
@@ -66,7 +66,6 @@ import time
 import numpy as np
 import scipy.linalg
 import scipy.sparse
-from scipy.sparse import sparsetools
 
 from gensim import interfaces, matutils, utils
 from gensim.models import basemodel
@@ -960,10 +959,8 @@ def stochastic_svd(
         m, n = corpus.shape
         assert num_terms == m, f"mismatch in number of features: {m} in sparse matrix vs. {num_terms} parameter"
         o = random_state.normal(0.0, 1.0, (n, samples)).astype(y.dtype)  # draw a random gaussian matrix
-        sparsetools.csc_matvecs(
-            m, n, samples, corpus.indptr, corpus.indices,
-            corpus.data, o.ravel(), y.ravel(),
-        )  # y = corpus * o
+        y = corpus.dot(o) # y = corpus * o
+
         del o
 
         # unlike np, scipy.sparse `astype()` copies everything, even if there is no change to dtype!
@@ -994,10 +991,7 @@ def stochastic_svd(
             num_docs += n
             logger.debug("multiplying chunk * gauss")
             o = random_state.normal(0.0, 1.0, (n, samples), ).astype(dtype)  # draw a random gaussian matrix
-            sparsetools.csc_matvecs(
-                m, n, samples, chunk.indptr, chunk.indices,  # y = y + chunk * o
-                chunk.data, o.ravel(), y.ravel(),
-            )
+            y = y + chunk * o
             del chunk, o
         y = [y]
         q, _ = matutils.qr_destroy(y)  # orthonormalize the range

--- a/gensim/models/nmf.py
+++ b/gensim/models/nmf.py
@@ -101,6 +101,7 @@ import logging
 import numpy as np
 import scipy.sparse
 from scipy.stats import halfnorm
+from scipy.sparse import csc_matrix
 
 from gensim import interfaces
 from gensim import matutils
@@ -575,7 +576,7 @@ class Nmf(interfaces.TransformationABC, basemodel.BaseTopicModel):
 
         lencorpus = np.inf
 
-        if isinstance(corpus, scipy.sparse.csc.csc_matrix):
+        if isinstance(corpus, csc_matrix):
             lencorpus = corpus.shape[1]
         else:
             try:
@@ -604,7 +605,7 @@ class Nmf(interfaces.TransformationABC, basemodel.BaseTopicModel):
         chunk_overall_idx = 1
 
         for pass_ in range(passes):
-            if isinstance(corpus, scipy.sparse.csc.csc_matrix):
+            if isinstance(corpus, csc_matrix):
                 grouper = (
                     # Older scipy (0.19 etc) throw an error when slicing beyond the actual sparse array dimensions, so
                     # we clip manually with min() here.
@@ -617,7 +618,7 @@ class Nmf(interfaces.TransformationABC, basemodel.BaseTopicModel):
                 grouper = utils.grouper(corpus, self.chunksize)
 
             for chunk_idx, chunk in enumerate(grouper):
-                if isinstance(corpus, scipy.sparse.csc.csc_matrix):
+                if isinstance(corpus, csc_matrix):
                     v = chunk[:, self.random_state.permutation(chunk.shape[1])]
 
                     chunk_len = v.shape[1]

--- a/gensim/test/test_poincare.py
+++ b/gensim/test/test_poincare.py
@@ -29,7 +29,7 @@ from gensim.test.utils import datapath
 logger = logging.getLogger(__name__)
 
 
-def testfile():
+def get_testfile():
     # temporary data will be stored to this file
     return os.path.join(tempfile.gettempdir(), 'gensim_word2vec.tst')
 
@@ -78,16 +78,16 @@ class TestPoincareModel(unittest.TestCase):
         """Tests whether the model is saved and loaded correctly."""
         model = PoincareModel(self.data, burn_in=0, negative=3)
         model.train(epochs=1)
-        model.save(testfile())
-        loaded = PoincareModel.load(testfile())
+        model.save(get_testfile())
+        loaded = PoincareModel.load(get_testfile())
         self.models_equal(model, loaded)
 
     def test_persistence_separate_file(self):
         """Tests whether the model is saved and loaded correctly when the arrays are stored separately."""
         model = PoincareModel(self.data, burn_in=0, negative=3)
         model.train(epochs=1)
-        model.save(testfile(), sep_limit=1)
-        loaded = PoincareModel.load(testfile())
+        model.save(get_testfile(), sep_limit=1)
+        loaded = PoincareModel.load(get_testfile())
         self.models_equal(model, loaded)
 
     def test_online_learning(self):
@@ -104,8 +104,8 @@ class TestPoincareModel(unittest.TestCase):
         """Tests whether the model can be trained correctly after loading from disk."""
         model = PoincareModel(self.data, burn_in=0, negative=3)
         model.train(epochs=1)
-        model.save(testfile())
-        loaded = PoincareModel.load(testfile())
+        model.save(get_testfile())
+        loaded = PoincareModel.load(get_testfile())
         model.train(epochs=1)
         loaded.train(epochs=1)
         self.models_equal(model, loaded)
@@ -238,7 +238,7 @@ class TestPoincareModel(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         try:
-            os.unlink(testfile())
+            os.unlink(get_testfile())
         except OSError:
             pass
 

--- a/gensim/test/test_similarities.py
+++ b/gensim/test/test_similarities.py
@@ -9,6 +9,7 @@ Automated tests for similarity algorithms (the similarities package).
 """
 
 import logging
+import sys
 import unittest
 import math
 import os
@@ -720,6 +721,7 @@ class TestWord2VecNmslibIndexer(unittest.TestCase):
         self.assertIndexSaved(index)
         self.assertLoadedIndexEqual(index, model)
 
+    @unittest.skipIf(sys.version_info[:2] == (3, 9), "Skip test on Python 3.9")
     def test_fasttext(self):
         class LeeReader:
             def __init__(self, fn):

--- a/gensim/test/test_similarities.py
+++ b/gensim/test/test_similarities.py
@@ -37,6 +37,7 @@ from gensim.similarities.fastss import editdist
 
 try:
     from ot import emd2  # noqa:F401
+
     POT_EXT = True
 except (ImportError, ValueError):
     POT_EXT = False
@@ -354,7 +355,7 @@ class TestWmdSimilarity(_TestSimilarityABC):
         sims = index[query]
 
         for i in range(3):
-            self.assertTrue(numpy.all(sims[i, i] == 1.0)) # Similarity of a document with itself is 0.0.
+            self.assertTrue(numpy.all(sims[i, i] == 1.0))  # Similarity of a document with itself is 0.0.
 
         # test the same thing but with num_best
         index.num_best = 3
@@ -1499,7 +1500,7 @@ class TestSparseTermSimilarityMatrix(unittest.TestCase):
         expected_result *= math.sqrt(self.identity_matrix.inner_product(self.vec2, self.vec2))
         expected_result = numpy.full((3, 2), expected_result)
         result = self.uniform_matrix.inner_product([self.vec1] * 3, [self.vec2] * 2,
-            normalized=('maintain', 'maintain'))
+                                                   normalized=('maintain', 'maintain'))
         self.assertTrue(isinstance(result, scipy.sparse.csr_matrix))
         self.assertTrue(numpy.allclose(expected_result, result.todense()))
 
@@ -1634,7 +1635,7 @@ class TestWordEmbeddingSimilarityIndex(unittest.TestCase):
         first_similarities = numpy.array([similarity for term, similarity in index.most_similar(u"holiday", topn=10)])
         index = WordEmbeddingSimilarityIndex(self.vectors, exponent=2.0)
         second_similarities = numpy.array([similarity for term, similarity in index.most_similar(u"holiday", topn=10)])
-        self.assertTrue(numpy.allclose(first_similarities**2.0, second_similarities))
+        self.assertTrue(numpy.allclose(first_similarities ** 2.0, second_similarities))
 
 
 class TestFastSS(unittest.TestCase):

--- a/gensim/test/test_similarities.py
+++ b/gensim/test/test_similarities.py
@@ -323,11 +323,11 @@ class TestWmdSimilarity(_TestSimilarityABC):
             # Sparse array.
             for i, sim in sims:
                 # Note that similarities are bigger than zero, as they are the 1/ 1 + distances.
-                self.assertTrue(numpy.alltrue(sim > 0.0))
+                self.assertTrue(numpy.all(sim > 0.0))
         else:
             self.assertTrue(sims[0] == 1.0)  # Similarity of a document with itself is 0.0.
-            self.assertTrue(numpy.alltrue(sims[1:] > 0.0))
-            self.assertTrue(numpy.alltrue(sims[1:] < 1.0))
+            self.assertTrue(numpy.all(sims[1:] > 0.0))
+            self.assertTrue(numpy.all(sims[1:] < 1.0))
 
     @unittest.skipIf(POT_EXT is False, "POT not installed")
     def test_non_increasing(self):
@@ -354,15 +354,15 @@ class TestWmdSimilarity(_TestSimilarityABC):
         sims = index[query]
 
         for i in range(3):
-            self.assertTrue(numpy.alltrue(sims[i, i] == 1.0))  # Similarity of a document with itself is 0.0.
+            self.assertTrue(numpy.all(sims[i, i] == 1.0)) # Similarity of a document with itself is 0.0.
 
         # test the same thing but with num_best
         index.num_best = 3
         sims = index[query]
         for sims_temp in sims:
             for i, sim in sims_temp:
-                self.assertTrue(numpy.alltrue(sim > 0.0))
-                self.assertTrue(numpy.alltrue(sim <= 1.0))
+                self.assertTrue(numpy.all(sim > 0.0))
+                self.assertTrue(numpy.all(sim <= 1.0))
 
     @unittest.skipIf(POT_EXT is False, "POT not installed")
     def test_iter(self):
@@ -370,8 +370,8 @@ class TestWmdSimilarity(_TestSimilarityABC):
 
         index = self.cls(TEXTS, self.w2v_model)
         for sims in index:
-            self.assertTrue(numpy.alltrue(sims >= 0.0))
-            self.assertTrue(numpy.alltrue(sims <= 1.0))
+            self.assertTrue(numpy.all(sims >= 0.0))
+            self.assertTrue(numpy.all(sims <= 1.0))
 
     @unittest.skipIf(POT_EXT is False, "POT not installed")
     def test_str(self):
@@ -399,12 +399,12 @@ class TestSoftCosineSimilarity(_TestSimilarityABC):
         if num_best is not None:
             # Sparse array.
             for i, sim in sims:
-                self.assertTrue(numpy.alltrue(sim <= 1.0))
-                self.assertTrue(numpy.alltrue(sim >= 0.0))
+                self.assertTrue(numpy.all(sim <= 1.0))
+                self.assertTrue(numpy.all(sim >= 0.0))
         else:
             self.assertAlmostEqual(1.0, sims[0])  # Similarity of a document with itself is 1.0.
-            self.assertTrue(numpy.alltrue(sims[1:] >= 0.0))
-            self.assertTrue(numpy.alltrue(sims[1:] < 1.0))
+            self.assertTrue(numpy.all(sims[1:] >= 0.0))
+            self.assertTrue(numpy.all(sims[1:] < 1.0))
 
         # Corpora
         for query in (
@@ -416,15 +416,15 @@ class TestSoftCosineSimilarity(_TestSimilarityABC):
                 # Sparse array.
                 for result in sims:
                     for i, sim in result:
-                        self.assertTrue(numpy.alltrue(sim <= 1.0))
-                        self.assertTrue(numpy.alltrue(sim >= 0.0))
+                        self.assertTrue(numpy.all(sim <= 1.0))
+                        self.assertTrue(numpy.all(sim >= 0.0))
             else:
                 for i, result in enumerate(sims):
                     self.assertAlmostEqual(1.0, result[i])  # Similarity of a document with itself is 1.0.
-                    self.assertTrue(numpy.alltrue(result[:i] >= 0.0))
-                    self.assertTrue(numpy.alltrue(result[:i] < 1.0))
-                    self.assertTrue(numpy.alltrue(result[i + 1:] >= 0.0))
-                    self.assertTrue(numpy.alltrue(result[i + 1:] < 1.0))
+                    self.assertTrue(numpy.all(result[:i] >= 0.0))
+                    self.assertTrue(numpy.all(result[:i] < 1.0))
+                    self.assertTrue(numpy.all(result[i + 1:] >= 0.0))
+                    self.assertTrue(numpy.all(result[i + 1:] < 1.0))
 
     def test_non_increasing(self):
         """ Check that similarities are non-increasing when `num_best` is not `None`."""
@@ -445,7 +445,7 @@ class TestSoftCosineSimilarity(_TestSimilarityABC):
         sims = index[query]
 
         for i in range(3):
-            self.assertTrue(numpy.alltrue(sims[i, i] == 1.0))  # Similarity of a document with itself is 1.0.
+            self.assertTrue(numpy.all(sims[i, i] == 1.0))  # Similarity of a document with itself is 1.0.
 
         # test the same thing but with num_best
         index.num_best = 5
@@ -459,8 +459,8 @@ class TestSoftCosineSimilarity(_TestSimilarityABC):
     def test_iter(self):
         index = self.cls(CORPUS, self.similarity_matrix)
         for sims in index:
-            self.assertTrue(numpy.alltrue(sims >= 0.0))
-            self.assertTrue(numpy.alltrue(sims <= 1.0))
+            self.assertTrue(numpy.all(sims >= 0.0))
+            self.assertTrue(numpy.all(sims <= 1.0))
 
 
 class TestSparseMatrixSimilarity(_TestSimilarityABC):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,10 @@ requires = [
     "Cython>=0.29.32,<3.0.0",
     # oldest supported Numpy for this platform is 1.17 but the oldest supported by Gensim
     # is 1.18.5, remove the line when they increase oldest supported Numpy for this platform
-    "numpy==1.18.5; python_version=='3.8' and platform_machine not in 'arm64|aarch64'",
-    "oldest-supported-numpy; python_version>'3.8' or platform_machine in 'arm64|aarch64'",
+    # 20240604 GM: testing numpy-2.0.0rc2 which requires python >= 3.9 (to 3.12)
+    "numpy==2.0.0rc2; python_version>='3.9' and platform_machine not in 'arm64|aarch64'",
+    # "oldest-supported-numpy; python_version>'3.8' or platform_machine in 'arm64|aarch64'",
+    "scipy",
     "setuptools",
     "wheel",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
     # oldest supported Numpy for this platform is 1.17 but the oldest supported by Gensim
     # is 1.18.5, remove the line when they increase oldest supported Numpy for this platform
     # 20240604 GM: testing numpy-2.0.0rc2 which requires python >= 3.9 (to 3.12)
-    "numpy==2.0.0rc2; python_version>='3.9' and platform_machine not in 'arm64|aarch64'",
+    "numpy==2.0.0; python_version>='3.9' and platform_machine not in 'arm64|aarch64'",
     # "oldest-supported-numpy; python_version>'3.8' or platform_machine in 'arm64|aarch64'",
     "scipy",
     "setuptools",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
     "Cython>=0.29.32,<3.0.0",
     # oldest supported Numpy for this platform is 1.17 but the oldest supported by Gensim
     # is 1.18.5, remove the line when they increase oldest supported Numpy for this platform
-    # 20240604 GM: testing numpy-2.0.0rc2 which requires python >= 3.9 (to 3.12)
+    # 20240604 GM: testing numpy-2.0.0 which requires python >= 3.9 (to 3.12)
     "numpy==2.0.0; python_version>='3.9' and platform_machine not in 'arm64|aarch64'",
     # "oldest-supported-numpy; python_version>'3.8' or platform_machine in 'arm64|aarch64'",
     "scipy",

--- a/setup.py
+++ b/setup.py
@@ -324,7 +324,7 @@ docs_testenv = core_testenv + distributed_env + visdom_req + [
     'pandas',
 ]
 
-NUMPY_STR = 'numpy == 2.0.0rc2'
+NUMPY_STR = 'numpy == 2.0.0'
 
 install_requires = [
     NUMPY_STR,

--- a/setup.py
+++ b/setup.py
@@ -337,7 +337,7 @@ install_requires = [
 
 setup(
     name='gensim',
-    version='4.3.2.np2test0',
+    version='4.4.0a0.dev0',
     description='Python framework for fast Vector Space Modelling',
     long_description=LONG_DESCRIPTION,
 

--- a/setup.py
+++ b/setup.py
@@ -324,10 +324,7 @@ docs_testenv = core_testenv + distributed_env + visdom_req + [
     'pandas',
 ]
 
-#
-# see https://github.com/piskvorky/gensim/pull/3535
-#
-NUMPY_STR = 'numpy >= 1.18.5, < 2.0'
+NUMPY_STR = 'numpy == 2.0.0rc2'
 
 install_requires = [
     NUMPY_STR,
@@ -340,7 +337,7 @@ install_requires = [
 
 setup(
     name='gensim',
-    version='4.3.3',
+    version='4.3.2.np2test0',
     description='Python framework for fast Vector Space Modelling',
     long_description=LONG_DESCRIPTION,
 

--- a/setup.py
+++ b/setup.py
@@ -370,7 +370,6 @@ setup(
         'Environment :: Console',
         'Intended Audience :: Science/Research',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
@@ -382,7 +381,7 @@ setup(
     ],
 
     test_suite="gensim.test",
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     install_requires=install_requires,
     tests_require=linux_testenv,
     extras_require={


### PR DESCRIPTION
Hey @gojomo @hechth @piskvorky @mpenkov,
I've created a new PR for the Migration to numPy 2.0 and the removal of deprecated scipy functions. What has been done so far:

- [x] Updated dtypes for functions where tests were failing
- [x] Fixed some numpy assertions alltrue -> all
- [x] **Python 3.8** has been removed from the supported versions
- [x] Fixed deprecated scipy import for csc_matrix
- [x] Fixed deifferent behaviour for argsort, where multiple results on the same level were sorted differently

What needs to be done:
- [ ] Remove NMSLibIndexer since it will only work on numPy 1.0? (See [this comment](https://github.com/piskvorky/gensim/issues/3560#issuecomment-2937318329))
- [ ] For Python 3.13 support some parts of [word2vec.pyx](https://github.com/piskvorky/gensim/blob/develop/gensim/models/word2vec_inner.pyx) need to be adapted (See #3611). However, Python 3.9-3.12 work perfectly. Should 3.13 support incorporated in this PR or in a different one?
- [ ] CI pipeline is failing due to outdated Runners and arch for latest macOS Runner needs to be adapted. (See #3607). I'll try to fix these in a different PR.

Hope we get this done now 💪